### PR TITLE
Expand calculator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive web-based financial management tool featuring:
 
 - 📊 Investment Portfolio Management
 - 🏦 Pension Tracking & Projections  
-- 🧮 Loan & Investment Calculators
+- 🧮 Calculators (Loan, Investment, CAGR and Fair Value)
 - 📈 Stock Performance Tracker
 
 ## Features

--- a/calculator.js
+++ b/calculator.js
@@ -1,4 +1,5 @@
 let activeCalculator = 'loan';
+let activeFVTab = 'dcf';
 
 function setupInvestmentYears() {
     const select = document.getElementById('invest-years');
@@ -93,6 +94,76 @@ function renderGrowthTable(amount, rate, years) {
     document.getElementById('growth-table-content').innerHTML = html;
 }
 
+function calculateCAGR() {
+    const start = parseFloat(document.getElementById('cagr-start').value) || 0;
+    const end = parseFloat(document.getElementById('cagr-end').value) || 0;
+    const years = parseFloat(document.getElementById('cagr-years').value) || 0;
+
+    if (start > 0 && end > 0 && years > 0) {
+        const cagr = Math.pow(end / start, 1 / years) - 1;
+        document.getElementById('cagr-result').textContent = `${(cagr * 100).toFixed(2)}%`;
+    } else {
+        document.getElementById('cagr-result').textContent = '0%';
+    }
+}
+
+function calculateDCF() {
+    const cashFlow = parseFloat(document.getElementById('dcf-cashflow').value) || 0;
+    const growth = parseFloat(document.getElementById('dcf-growth').value) || 0;
+    const discount = parseFloat(document.getElementById('dcf-discount').value) || 0;
+    const years = parseInt(document.getElementById('dcf-years').value) || 0;
+
+    if (cashFlow > 0 && discount > 0 && years > 0) {
+        let value = 0;
+        for (let i = 1; i <= years; i++) {
+            const cf = cashFlow * Math.pow(1 + growth / 100, i);
+            value += cf / Math.pow(1 + discount / 100, i);
+        }
+        document.getElementById('dcf-result').textContent =
+            `£${value.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    } else {
+        document.getElementById('dcf-result').textContent = '£0.00';
+    }
+}
+
+function calculatePE() {
+    const eps = parseFloat(document.getElementById('pe-eps').value) || 0;
+    const growth = parseFloat(document.getElementById('pe-growth').value) || 0;
+    const years = parseInt(document.getElementById('pe-years').value) || 0;
+    const pe = parseFloat(document.getElementById('pe-ratio').value) || 0;
+
+    if (eps > 0 && pe > 0) {
+        const futureEPS = eps * Math.pow(1 + growth / 100, years);
+        const value = futureEPS * pe;
+        document.getElementById('pe-result').textContent =
+            `£${value.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    } else {
+        document.getElementById('pe-result').textContent = '£0.00';
+    }
+}
+
+function calculateIntrinsic() {
+    const book = parseFloat(document.getElementById('intrinsic-book').value) || 0;
+    const growth = parseFloat(document.getElementById('intrinsic-growth').value) || 0;
+    const years = parseInt(document.getElementById('intrinsic-years').value) || 0;
+
+    if (book > 0) {
+        const value = book * Math.pow(1 + growth / 100, years);
+        document.getElementById('intrinsic-result').textContent =
+            `£${value.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    } else {
+        document.getElementById('intrinsic-result').textContent = '£0.00';
+    }
+}
+
+function switchFVTab(tab) {
+    activeFVTab = tab;
+    document.querySelectorAll('.fv-tab').forEach(t => t.classList.remove('active'));
+    document.querySelector(`[data-fv="${tab}"]`).classList.add('active');
+    document.querySelectorAll('.fv-calculator').forEach(c => c.classList.remove('active'));
+    document.getElementById(`${tab}-calc`).classList.add('active');
+}
+
 function setupListeners() {
     // Loan calculator listeners
     ['loan-amount', 'loan-rate', 'loan-term'].forEach(id => {
@@ -102,6 +173,31 @@ function setupListeners() {
     // Investment calculator listeners
     ['invest-amount', 'invest-rate', 'invest-years'].forEach(id => {
         document.getElementById(id).addEventListener('input', calculateInvestment);
+    });
+
+    // CAGR calculator listeners
+    ['cagr-start', 'cagr-end', 'cagr-years'].forEach(id => {
+        document.getElementById(id).addEventListener('input', calculateCAGR);
+    });
+
+    // DCF calculator listeners
+    ['dcf-cashflow', 'dcf-growth', 'dcf-discount', 'dcf-years'].forEach(id => {
+        document.getElementById(id).addEventListener('input', calculateDCF);
+    });
+
+    // PE calculator listeners
+    ['pe-eps', 'pe-growth', 'pe-years', 'pe-ratio'].forEach(id => {
+        document.getElementById(id).addEventListener('input', calculatePE);
+    });
+
+    // Intrinsic value calculator listeners
+    ['intrinsic-book', 'intrinsic-growth', 'intrinsic-years'].forEach(id => {
+        document.getElementById(id).addEventListener('input', calculateIntrinsic);
+    });
+
+    // Fair value tab navigation
+    document.querySelectorAll('.fv-tab').forEach(btn => {
+        btn.addEventListener('click', () => switchFVTab(btn.dataset.fv));
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
             <div class="calc-nav">
                 <button class="calc-tab active" data-calc="loan">💳 Loan Calculator</button>
                 <button class="calc-tab investment" data-calc="investment">📈 Investment Calculator</button>
+                <button class="calc-tab" data-calc="cagr">📊 CAGR Calculator</button>
+                <button class="calc-tab" data-calc="fairvalue">💰 Fair Value Calculator</button>
             </div>
 
             <!-- Loan Calculator -->
@@ -121,6 +123,116 @@
                                     Enter investment amount and return rate to see projections
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- CAGR Calculator -->
+            <div id="cagr-calc" class="calculator">
+                <div class="card">
+                    <h3 style="margin-bottom: 25px; font-size: 1.5rem; color: #2c3e50;">CAGR Calculator</h3>
+                    <div class="calc-inputs">
+                        <div class="input-group">
+                            <label class="input-label">Starting Value (£)</label>
+                            <input type="number" class="input-field" id="cagr-start" placeholder="Enter starting value">
+                        </div>
+                        <div class="input-group">
+                            <label class="input-label">Ending Value (£)</label>
+                            <input type="number" class="input-field" id="cagr-end" placeholder="Enter ending value">
+                        </div>
+                        <div class="input-group">
+                            <label class="input-label">Period (years)</label>
+                            <input type="number" class="input-field" id="cagr-years" placeholder="Number of years">
+                        </div>
+                    </div>
+                    <div class="result-card">
+                        <div class="result-label">CAGR</div>
+                        <div class="result-value" id="cagr-result">0%</div>
+                        <div class="result-sub">Enter values to calculate</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Fair Value Calculator -->
+            <div id="fairvalue-calc" class="calculator">
+                <div class="card">
+                    <h3 style="margin-bottom: 25px; font-size: 1.5rem; color: #2c3e50;">Fair Value Calculator</h3>
+                    <div class="fv-nav">
+                        <button class="fv-tab active" data-fv="dcf">DCF</button>
+                        <button class="fv-tab" data-fv="pe">PE</button>
+                        <button class="fv-tab" data-fv="intrinsic">Intrinsic Value</button>
+                    </div>
+                    <div id="dcf-calc" class="fv-calculator active">
+                        <div class="calc-inputs">
+                            <div class="input-group">
+                                <label class="input-label">Current Cash Flow (£)</label>
+                                <input type="number" class="input-field" id="dcf-cashflow" placeholder="Cash flow">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Growth Rate (%)</label>
+                                <input type="number" step="0.1" class="input-field" id="dcf-growth" placeholder="Growth rate">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Discount Rate (%)</label>
+                                <input type="number" step="0.1" class="input-field" id="dcf-discount" placeholder="Discount rate">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Years</label>
+                                <input type="number" class="input-field" id="dcf-years" placeholder="Projection years">
+                            </div>
+                        </div>
+                        <div class="result-card">
+                            <div class="result-label">DCF Value</div>
+                            <div class="result-value" id="dcf-result">£0.00</div>
+                            <div class="result-sub">Enter values to calculate</div>
+                        </div>
+                    </div>
+
+                    <div id="pe-calc" class="fv-calculator">
+                        <div class="calc-inputs">
+                            <div class="input-group">
+                                <label class="input-label">Earnings Per Share (£)</label>
+                                <input type="number" class="input-field" id="pe-eps" placeholder="EPS">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Growth Rate (%)</label>
+                                <input type="number" step="0.1" class="input-field" id="pe-growth" placeholder="Growth rate">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Years</label>
+                                <input type="number" class="input-field" id="pe-years" placeholder="Years">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Target P/E</label>
+                                <input type="number" class="input-field" id="pe-ratio" placeholder="P/E ratio">
+                            </div>
+                        </div>
+                        <div class="result-card">
+                            <div class="result-label">PE Value</div>
+                            <div class="result-value" id="pe-result">£0.00</div>
+                            <div class="result-sub">Enter values to calculate</div>
+                        </div>
+                    </div>
+
+                    <div id="intrinsic-calc" class="fv-calculator">
+                        <div class="calc-inputs">
+                            <div class="input-group">
+                                <label class="input-label">Book Value Per Share (£)</label>
+                                <input type="number" class="input-field" id="intrinsic-book" placeholder="Book value">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Growth Rate (%)</label>
+                                <input type="number" step="0.1" class="input-field" id="intrinsic-growth" placeholder="Growth rate">
+                            </div>
+                            <div class="input-group">
+                                <label class="input-label">Years</label>
+                                <input type="number" class="input-field" id="intrinsic-years" placeholder="Years">
+                            </div>
+                        </div>
+                        <div class="result-card">
+                            <div class="result-label">Intrinsic Value</div>
+                            <div class="result-value" id="intrinsic-result">£0.00</div>
+                            <div class="result-sub">Enter values to calculate</div>
                         </div>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -320,9 +320,47 @@
             box-shadow: 0 5px 15px rgba(52, 152, 219, 0.4);
         }
 
-        .calc-tab.active.investment {
-            background: #27ae60;
-            box-shadow: 0 5px 15px rgba(39, 174, 96, 0.4);
+.calc-tab.active.investment {
+    background: #27ae60;
+    box-shadow: 0 5px 15px rgba(39, 174, 96, 0.4);
+}
+
+        /* Fair value sub-navigation */
+        .fv-nav {
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+            margin-bottom: 20px;
+        }
+
+        .fv-tab {
+            background: #ecf0f1;
+            color: #2c3e50;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 50px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            font-weight: 600;
+        }
+
+        .fv-tab:hover {
+            background: #bdc3c7;
+        }
+
+        .fv-tab.active {
+            background: #9b59b6;
+            color: white;
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(155, 89, 182, 0.4);
+        }
+
+        .fv-calculator {
+            display: none;
+        }
+
+        .fv-calculator.active {
+            display: block;
         }
 
         .calculator {


### PR DESCRIPTION
## Summary
- rename calculators section in README
- add CAGR and Fair Value calculators with PE and intrinsic tabs
- style new calculator tabs
- implement calculation logic and event handling

## Testing
- `node -c calculator.js`
- `node -e "require('./calculator.js');console.log('loaded')"`

------
https://chatgpt.com/codex/tasks/task_e_686c4a96da7c832fbd320c43c9153ed1