### PR TITLE
Update header style and layout

### DIFF
--- a/financial_dashboard.html
+++ b/financial_dashboard.html
@@ -47,7 +47,8 @@
         }
 
         .header {
-            background: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-light));
+            background-color: var(--gosalci-bg);
+            background-image: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-light));
             color: white;
             padding: 1.5rem 2rem;
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
@@ -55,12 +56,14 @@
 
         .header-container {
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-start;
             align-items: center;
+            gap: 1rem;
         }
 
         .header-logo {
             height: 50px;
+            margin-right: 0.5rem;
         }
 
         .header h1 {
@@ -680,11 +683,11 @@
 <body>
     <header class="header">
         <div class="container header-container">
+            <img src="gosalci_logo.png" alt="GoSalci Logo" class="header-logo">
             <div class="header-text">
                 <h1>Financial Dashboard</h1>
                 <p>Personal Investment Tracking & Financial Planning Tool</p>
             </div>
-            <img src="gosalci_logo.png" alt="GoSalci Logo" class="header-logo">
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- keep the existing gradient but set the header background color to `gosalci-bg`
- arrange the header so the logo appears before the title
- tweak flexbox layout for the header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ce0de7cb0832f900c413625d8c62b