### PR TITLE
Fix chart popup sizing

### DIFF
--- a/financial_dashboard.html
+++ b/financial_dashboard.html
@@ -1049,7 +1049,8 @@
                     <div class="modal-content">
                         <span class="modal-close">&times;</span>
                         <h3 id="chart-title"></h3>
-                        <canvas id="popup-chart" width="600" height="400"></canvas>
+                        <!-- Enlarged canvas to accommodate larger price values -->
+                        <canvas id="popup-chart" width="800" height="500"></canvas>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- enlarge the chart canvas so large price values fit the popup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ce96779a4832fad7c7a1d84d0cfa8