### PR TITLE
Hide stock ticker tags outside of edit mode

### DIFF
--- a/financial_dashboard.html
+++ b/financial_dashboard.html
@@ -1586,15 +1586,18 @@
                     btn.style.display = editMode && stockData.tickers.length > 0 ? 'inline-flex' : 'none';
                 }
 
-                function applyEditMode() {
-                    const management = document.querySelector('#stock-tracker .ticker-management');
-                    if (management) management.style.display = editMode ? 'flex' : 'none';
+               function applyEditMode() {
+                   const management = document.querySelector('#stock-tracker .ticker-management');
+                   if (management) management.style.display = editMode ? 'flex' : 'none';
 
-                    const inputs = document.querySelectorAll('#performance-table input.price-input');
-                    inputs.forEach(inp => inp.readOnly = !editMode);
+                    const tags = document.getElementById('ticker-tags');
+                    if (tags) tags.style.display = editMode ? 'flex' : 'none';
 
-                    updateGenerateButton();
-                }
+                   const inputs = document.querySelectorAll('#performance-table input.price-input');
+                   inputs.forEach(inp => inp.readOnly = !editMode);
+
+                   updateGenerateButton();
+               }
 
                 function toggleEditMode() {
                     editMode = !editMode;


### PR DESCRIPTION
## Summary
- update Stock Performance Tracker edit mode logic
- hide ticker tags when not editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cec22fa3c832f89d641b62558afe0