### PR TITLE
Align yearly growth percentages under prices

### DIFF
--- a/financial_dashboard.html
+++ b/financial_dashboard.html
@@ -296,8 +296,16 @@
             background: var(--background-secondary);
         }
 
-        .price-input {
+        .price-cell {
             width: 120px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+        }
+
+        .price-input {
+            width: 100%;
+            display: block;
             padding: 0.5rem;
             border: 1px solid var(--border-color);
             border-radius: 6px;
@@ -307,15 +315,18 @@
         .growth-positive {
             color: var(--success-green);
             font-weight: 600;
+            text-align: right;
         }
 
         .growth-negative {
             color: var(--danger-red);
             font-weight: 600;
+            text-align: right;
         }
 
         .growth-neutral {
             color: var(--text-secondary);
+            text-align: right;
         }
 
         .summary-row {
@@ -1632,6 +1643,7 @@
                         
                         stockData.tickers.forEach(ticker => {
                             const cell = document.createElement('td');
+                            cell.className = 'price-cell';
                             const priceInput = document.createElement('input');
                             priceInput.type = 'number';
                             priceInput.className = 'price-input';
@@ -1660,6 +1672,7 @@
                                 growthDiv.className = 'growth-neutral';
                                 growthDiv.style.fontSize = '0.85rem';
                                 growthDiv.style.marginTop = '4px';
+                                growthDiv.style.textAlign = 'right';
                                 cell.appendChild(growthDiv);
                             }
                             


### PR DESCRIPTION
## Summary
- ensure price cells stack inputs and growth percentages
- add CSS for `.price-cell` so growth values align with prices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ceecde854832f99ff33b0f557ac44