### PR TITLE
Hide prices in stock tracker when not editing

### DIFF
--- a/financial_dashboard.html
+++ b/financial_dashboard.html
@@ -1607,7 +1607,10 @@
                     if (tags) tags.style.display = editMode ? 'flex' : 'none';
 
                    const inputs = document.querySelectorAll('#performance-table input.price-input');
-                   inputs.forEach(inp => inp.readOnly = !editMode);
+                   inputs.forEach(inp => {
+                       inp.readOnly = !editMode;
+                       inp.style.display = editMode ? 'block' : 'none';
+                   });
 
                    updateGenerateButton();
                }


### PR DESCRIPTION
## Summary
- hide year-end price inputs when Stock Performance Tracker is not in edit mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d64eba36c832fb499c218b50e86cd