### PR TITLE
Fix P&L% chart tooltip sign

### DIFF
--- a/app/js/script.js
+++ b/app/js/script.js
@@ -156,7 +156,11 @@
                                     legend: { display: false },
                                     tooltip: {
                                         callbacks: {
-                                            label: (ctx) => `${ctx.label}: ${ctx.parsed.toFixed(1)}%`
+                                            label: (ctx) => {
+                                                const val = ctx.parsed;
+                                                const sign = val > 0 ? '+' : '';
+                                                return `${ctx.label}: ${sign}${val.toFixed(1)}%`;
+                                            }
                                         }
                                     },
                                     title: { display: true, text: 'P&L%' }


### PR DESCRIPTION
## Summary
- show plus sign in the P&L% tooltip so growth is clear

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eedcb5494832f99c05b7c06d21877