### PR TITLE
Fix P&L% chart tooltip sign

### DIFF
--- a/app/js/script.js
+++ b/app/js/script.js
@@ -156,7 +156,13 @@
                                     legend: { display: false },
                                     tooltip: {
                                         callbacks: {
-                                            label: (ctx) => `${ctx.label}: ${ctx.parsed.toFixed(1)}%`
+                                            label: (ctx) => {
+                                                const val = typeof ctx.parsed === 'object'
+                                                    ? (ctx.parsed.y ?? ctx.parsed.x)
+                                                    : ctx.parsed;
+                                                const sign = val > 0 ? '+' : '';
+                                                return `${ctx.label}: ${sign}${val.toFixed(1)}%`;
+                                            }
                                         }
                                     },
                                     title: { display: true, text: 'P&L%' }


### PR DESCRIPTION
## Summary
- fix tooltip callback to read numeric value correctly and show plus sign

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eedcb5494832f99c05b7c06d21877