### PR TITLE
Add Stock Finance Performance tab

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -398,6 +398,40 @@
             color: var(--primary-blue);
         }
 
+        /* Financials Section */
+        .financial-item {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            background: var(--background-secondary);
+        }
+
+        .financial-item h4 {
+            margin-bottom: 1rem;
+            color: var(--primary-blue);
+        }
+
+        .statement-group {
+            margin-bottom: 1rem;
+        }
+
+        .statement-group h5 {
+            margin-bottom: 0.5rem;
+            color: var(--text-primary);
+        }
+
+        .statement-row {
+            display: flex;
+            justify-content: space-between;
+            padding: 0.25rem 0;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .statement-row:last-child {
+            border-bottom: none;
+        }
+
         .ticker-management {
             display: flex;
             gap: 1rem;

--- a/app/financial_dashboard.html
+++ b/app/financial_dashboard.html
@@ -507,10 +507,19 @@
             
             <!-- Stock Finance Performance Tab -->
             <div id="stock-finance" class="tab-content">
-                <div class="placeholder-content">
-                    <h3>Stock Finance Performance</h3>
-                    <p>Comprehensive financial analysis and performance metrics for your stock investments. This section will include detailed financial ratios, comparative analysis, sector performance benchmarking, and advanced stock valuation metrics to help you make informed investment decisions.</p>
+                <div class="section-header">
+                    <h2 class="section-title">Stock Finance Performance</h2>
                 </div>
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label for="finance-ticker-input">Stock Ticker</label>
+                        <input type="text" id="finance-ticker-input" style="text-transform: uppercase;">
+                    </div>
+                    <div class="form-group" style="align-items:flex-end;">
+                        <button class="btn btn-primary" id="fetch-financial-btn">Get Financial Details</button>
+                    </div>
+                </div>
+                <div id="financial-results" class="result-display" style="display:none;"></div>
             </div>
         </div>
     </div>

--- a/app/index.html
+++ b/app/index.html
@@ -507,10 +507,19 @@
             
             <!-- Stock Finance Performance Tab -->
             <div id="stock-finance" class="tab-content">
-                <div class="placeholder-content">
-                    <h3>Stock Finance Performance</h3>
-                    <p>Comprehensive financial analysis and performance metrics for your stock investments. This section will include detailed financial ratios, comparative analysis, sector performance benchmarking, and advanced stock valuation metrics to help you make informed investment decisions.</p>
+                <div class="section-header">
+                    <h2 class="section-title">Stock Finance Performance</h2>
                 </div>
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label for="finance-ticker-input">Stock Ticker</label>
+                        <input type="text" id="finance-ticker-input" style="text-transform: uppercase;">
+                    </div>
+                    <div class="form-group" style="align-items:flex-end;">
+                        <button class="btn btn-primary" id="fetch-financial-btn">Get Financial Details</button>
+                    </div>
+                </div>
+                <div id="financial-results" class="result-display" style="display:none;"></div>
             </div>
         </div>
     </div>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -65,31 +65,51 @@
                     try {
                         const res = await fetch(url);
                         const data = await res.json();
-                        renderData(data, container);
+                        displayFinancials(data, container);
                     } catch (e) {
                         container.innerHTML = '<div class="result-item">Failed to fetch data.</div>';
                     }
                     container.style.display = 'block';
                 }
 
-                function renderData(obj, container, indent = 0) {
-                    if (!obj || typeof obj !== 'object') return;
-                    Object.entries(obj).forEach(([key, value]) => {
-                        if (value && typeof value === 'object') {
-                            const header = document.createElement('div');
-                            header.textContent = key;
-                            header.style.fontWeight = '600';
-                            header.style.margin = '0.5rem 0';
-                            header.style.marginLeft = indent + 'rem';
-                            container.appendChild(header);
-                            renderData(value, container, indent + 1);
-                        } else {
-                            const row = document.createElement('div');
-                            row.className = 'result-item';
-                            row.style.marginLeft = indent + 'rem';
-                            row.innerHTML = `<span>${key}</span><span>${value}</span>`;
-                            container.appendChild(row);
-                        }
+                function createRow(key, value) {
+                    const row = document.createElement('div');
+                    row.className = 'statement-row';
+                    row.innerHTML = `<span>${key}</span><span>${value}</span>`;
+                    return row;
+                }
+
+                function renderStatement(title, dataObj, parent) {
+                    const group = document.createElement('div');
+                    group.className = 'statement-group';
+                    const header = document.createElement('h5');
+                    header.textContent = title;
+                    group.appendChild(header);
+                    Object.entries(dataObj || {}).forEach(([k, v]) => {
+                        group.appendChild(createRow(k, v));
+                    });
+                    parent.appendChild(group);
+                }
+
+                function displayFinancials(data, container) {
+                    if (!data || !Array.isArray(data.data)) {
+                        container.innerHTML = '<div class="result-item">No data available.</div>';
+                        return;
+                    }
+                    data.data.forEach(entry => {
+                        const item = document.createElement('div');
+                        item.className = 'financial-item';
+                        const heading = document.createElement('h4');
+                        const yr = entry.year || '';
+                        const qt = entry.quarter ? `Q${entry.quarter}` : '';
+                        heading.textContent = `${yr} ${qt} ${entry.form || ''}`.trim();
+                        item.appendChild(heading);
+                        const report = entry.report || {};
+                        Object.entries(report).forEach(([statement, details]) => {
+                            const title = statement.replace(/_/g, ' ').toUpperCase();
+                            renderStatement(title, details, item);
+                        });
+                        container.appendChild(item);
                     });
                 }
 

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -49,6 +49,62 @@
                 };
             })();
 
+            // Stock Finance Performance Module
+            const StockFinance = (function() {
+                const API_KEY = 'd1nf8h1r01qovv8iu2dgd1nf8h1r01qovv8iu2e0';
+
+                async function fetchFinancials() {
+                    const input = document.getElementById('finance-ticker-input');
+                    const ticker = input.value.trim().toUpperCase();
+                    if (!ticker) return;
+
+                    const container = document.getElementById('financial-results');
+                    container.innerHTML = '';
+
+                    const url = `https://finnhub.io/api/v1/stock/financials-reported?symbol=${encodeURIComponent(ticker)}&token=${API_KEY}`;
+                    try {
+                        const res = await fetch(url);
+                        const data = await res.json();
+                        renderData(data, container);
+                    } catch (e) {
+                        container.innerHTML = '<div class="result-item">Failed to fetch data.</div>';
+                    }
+                    container.style.display = 'block';
+                }
+
+                function renderData(obj, container, indent = 0) {
+                    if (!obj || typeof obj !== 'object') return;
+                    Object.entries(obj).forEach(([key, value]) => {
+                        if (value && typeof value === 'object') {
+                            const header = document.createElement('div');
+                            header.textContent = key;
+                            header.style.fontWeight = '600';
+                            header.style.margin = '0.5rem 0';
+                            header.style.marginLeft = indent + 'rem';
+                            container.appendChild(header);
+                            renderData(value, container, indent + 1);
+                        } else {
+                            const row = document.createElement('div');
+                            row.className = 'result-item';
+                            row.style.marginLeft = indent + 'rem';
+                            row.innerHTML = `<span>${key}</span><span>${value}</span>`;
+                            container.appendChild(row);
+                        }
+                    });
+                }
+
+                function init() {
+                    const btn = document.getElementById('fetch-financial-btn');
+                    if (btn) btn.addEventListener('click', fetchFinancials);
+                    const input = document.getElementById('finance-ticker-input');
+                    if (input) input.addEventListener('keypress', (e) => {
+                        if (e.key === 'Enter') fetchFinancials();
+                    });
+                }
+
+                return { init };
+            })();
+
             // Portfolio Management Module
             const PortfolioManager = (function() {
                 const STORAGE_KEY = 'portfolioData';
@@ -1319,6 +1375,7 @@
             // Public API
             function init() {
                 TabManager.init();
+                StockFinance.init();
                 PortfolioManager.init();
                 Calculator.init();
                 StockTracker.init();


### PR DESCRIPTION
## Summary
- implement Stock Finance Performance feature
- add new tab layout and JS module
- enable fetching "Financials As Reported" from Finnhub

## Testing
- `npm install --silent`
- `npm test --silent`
- `node app/js/node_modules/jest/bin/jest.js --config app/js/jest.config.js --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_686f043e8b78832f92fa9dc92bc8bfd1