### PR TITLE
Add onboarding overlay for first-time users

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -663,6 +663,33 @@
             z-index: 1000;
         }
 
+        /* Onboarding overlay */
+        .onboarding-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.7);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 1100;
+        }
+
+        .onboarding-content {
+            background: var(--background-primary);
+            padding: 2rem;
+            border-radius: 8px;
+            max-width: 600px;
+            text-align: left;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        }
+
+        .onboarding-close {
+            margin-top: 1rem;
+        }
+
         .modal-content {
             background: var(--background-primary);
             padding: 1rem;

--- a/app/index.html
+++ b/app/index.html
@@ -512,6 +512,14 @@
                     <p>Comprehensive financial analysis and performance metrics for your stock investments. This section will include detailed financial ratios, comparative analysis, sector performance benchmarking, and advanced stock valuation metrics to help you make informed investment decisions.</p>
                 </div>
             </div>
+    </div>
+</div>
+
+    <div id="onboarding-overlay" class="onboarding-overlay">
+        <div class="onboarding-content">
+            <h2>Welcome to the Financial Dashboard</h2>
+            <p>This brief guide helps you start tracking your investments. Use the <strong>Add Investment</strong> button in the Portfolio tab to add your first holding.</p>
+            <button id="onboarding-close" class="btn btn-primary onboarding-close">Got it</button>
         </div>
     </div>
 

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -49,6 +49,36 @@
                 };
             })();
 
+            // Onboarding Module
+            const Onboarding = (function() {
+                const STORAGE_KEY = 'seenOnboarding';
+                const overlay = document.getElementById('onboarding-overlay');
+                const closeBtn = document.getElementById('onboarding-close');
+
+                function show() {
+                    if (overlay) {
+                        overlay.style.display = 'flex';
+                    }
+                }
+
+                function hide() {
+                    if (overlay) {
+                        overlay.style.display = 'none';
+                    }
+                    localStorage.setItem(STORAGE_KEY, 'true');
+                }
+
+                function init() {
+                    if (!overlay || !closeBtn) return;
+                    closeBtn.addEventListener('click', hide);
+                    if (!localStorage.getItem(STORAGE_KEY)) {
+                        show();
+                    }
+                }
+
+                return { init };
+            })();
+
             // Portfolio Management Module
             const PortfolioManager = (function() {
                 const STORAGE_KEY = 'portfolioData';
@@ -1384,6 +1414,7 @@
                 PortfolioManager.init();
                 Calculator.init();
                 StockTracker.init();
+                Onboarding.init();
             }
 
             function removeTicker(ticker) {


### PR DESCRIPTION
## Summary
- add onboarding modal markup
- style onboarding overlay
- show onboarding on first visit via localStorage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f110f595c832fa55e8e596729d642