### PR TITLE
Add last price fetching to Stock Tracker

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -445,7 +445,10 @@
             <div id="stock-tracker" class="tab-content">
                 <div class="section-header">
                     <h2 class="section-title">Stock Performance Tracker</h2>
-                    <button class="btn btn-secondary" id="edit-stock-btn">Edit</button>
+                    <div>
+                        <button class="btn btn-secondary" id="edit-stock-btn">Edit</button>
+                        <button class="btn btn-secondary" id="get-stock-last-price-btn">Get The Last Price</button>
+                    </div>
                 </div>
                 
                 <div class="ticker-management" style="display: none;">


### PR DESCRIPTION
## Summary
- add `Get The Last Price` button to Stock Performance Tracker
- support storing ticker/year info on table inputs
- implement last price retrieval via Quote API
- update table and summary when prices are fetched

## Testing
- `npm --prefix app/js test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f7664beb8832f9ed92dd900647eef