### PR TITLE
Enable drag-and-drop reorder in portfolio table

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -275,19 +275,19 @@
             z-index: 2;
         }
 
-        .data-table th:first-child,
-        .data-table td:first-child {
+        .data-table th:nth-child(2),
+        .data-table td:nth-child(2) {
             position: sticky;
             left: 0;
             z-index: 1;
             background: var(--background-primary);
         }
 
-        .data-table .summary-row td:first-child {
+        .data-table .summary-row td:nth-child(2) {
             background: var(--background-secondary);
         }
 
-        .data-table tbody tr:hover td:first-child {
+        .data-table tbody tr:hover td:nth-child(2) {
             background: var(--background-secondary);
         }
 
@@ -724,6 +724,25 @@
 
         .actions-cell {
             white-space: nowrap;
+        }
+
+        .drag-handle-cell {
+            width: 24px;
+            text-align: center;
+            cursor: grab;
+        }
+
+        tr.dragging .drag-handle-cell {
+            cursor: grabbing;
+        }
+
+        tr.dragging {
+            opacity: 0.5;
+        }
+
+        .drag-handle-cell ion-icon {
+            font-size: 20px;
+            color: var(--text-secondary);
         }
 
         .icon-btn {

--- a/app/financial_dashboard.html
+++ b/app/financial_dashboard.html
@@ -43,6 +43,7 @@
                     <table class="data-table" id="portfolio-table">
                         <thead>
                             <tr>
+                                <th></th>
                                 <th>Ticker</th>
                                 <th>Name</th>
                                 <th>Average Price</th>
@@ -57,6 +58,7 @@
                         <tbody id="portfolio-body"></tbody>
                         <tfoot>
                             <tr class="summary-row">
+                                <td></td>
                                 <td colspan="5">Total</td>
                                 <td id="portfolio-total-value" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-pl" class="number-cell">$0.00</td>

--- a/app/index.html
+++ b/app/index.html
@@ -43,6 +43,7 @@
                     <table class="data-table" id="portfolio-table">
                         <thead>
                             <tr>
+                                <th></th>
                                 <th>Ticker</th>
                                 <th>Name</th>
                                 <th>Average Price</th>
@@ -57,6 +58,7 @@
                         <tbody id="portfolio-body"></tbody>
                         <tfoot>
                             <tr class="summary-row">
+                                <td></td>
                                 <td colspan="5">Total</td>
                                 <td id="portfolio-total-value" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-pl" class="number-cell">$0.00</td>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -269,7 +269,10 @@
                     tbody.innerHTML = '';
                     investments.forEach((inv, idx) => {
                         const row = document.createElement('tr');
+                        row.dataset.index = idx;
+                        row.draggable = true;
                         row.innerHTML = `
+                            <td class="drag-handle-cell"><ion-icon name="reorder-three-outline"></ion-icon></td>
                             <td>${inv.ticker}</td>
                             <td>${inv.name}</td>
                             <td class="number-cell">${formatCurrency(inv.avgPrice)}</td>
@@ -286,6 +289,7 @@
                                     <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                                 </button>
                             </td>`;
+                        addDragHandlers(row);
                         tbody.appendChild(row);
                     });
 
@@ -309,6 +313,39 @@
                         row.querySelector('.plpct-cell').textContent = plPct.toFixed(2) + '%';
                         row.querySelector('.plpct-cell').className = 'plpct-cell ' + (plPct >= 0 ? 'growth-positive' : 'growth-negative');
                     });
+                }
+
+                let dragStartIndex = null;
+
+                function handleDragStart() {
+                    dragStartIndex = parseInt(this.dataset.index, 10);
+                    this.classList.add('dragging');
+                }
+
+                function handleDragOver(e) {
+                    e.preventDefault();
+                }
+
+                function handleDrop() {
+                    const dropIndex = parseInt(this.dataset.index, 10);
+                    if (dragStartIndex === null || dragStartIndex === dropIndex) return;
+                    const item = investments.splice(dragStartIndex, 1)[0];
+                    const targetIndex = dragStartIndex < dropIndex ? dropIndex - 1 : dropIndex;
+                    investments.splice(targetIndex, 0, item);
+                    dragStartIndex = null;
+                    saveData();
+                    renderTable();
+                }
+
+                function handleDragEnd() {
+                    this.classList.remove('dragging');
+                }
+
+                function addDragHandlers(row) {
+                    row.addEventListener('dragstart', handleDragStart);
+                    row.addEventListener('dragover', handleDragOver);
+                    row.addEventListener('drop', handleDrop);
+                    row.addEventListener('dragend', handleDragEnd);
                 }
 
                 function openModal() {


### PR DESCRIPTION
## Summary
- allow repositioning portfolio rows via drag & drop
- add drag handle column with icon
- adjust sticky column styles

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686f7dc7762c832f8c243ce873456b39