### PR TITLE
Add trade date and portfolio growth tracking

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -798,5 +798,6 @@
 
         .chart-box canvas {
             width: 100%;
-            height: 300px;
+            height: 200px;
         }
+#portfolio-growth-chart { height: 200px; }

--- a/app/index.html
+++ b/app/index.html
@@ -39,6 +39,10 @@
                         <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
                     </div>
                 </div>
+                <div class="chart-box" id="growth-chart-box">
+                    <h3>Portfolio Growth</h3>
+                    <canvas id="portfolio-growth-chart"></canvas>
+                </div>
                 <div class="table-container" id="portfolio-table-container">
                     <table class="data-table" id="portfolio-table">
                         <thead>
@@ -106,6 +110,10 @@
                                 <div class="form-group">
                                     <label for="investment-last-price">Last Price</label>
                                     <input type="number" step="0.01" id="investment-last-price" required>
+                                </div>
+                                <div class="form-group">
+                                    <label for="investment-trade-date">Trade Date</label>
+                                    <input type="date" id="investment-trade-date" required>
                                 </div>
                                 <div class="form-group">
                                     <label>Total Value</label>


### PR DESCRIPTION
## Summary
- add portfolio growth chart and render it above the table
- add Trade Date field when adding investments
- persist individual trades and load them at startup
- compute monthly portfolio value from trade history
- adjust chart heights

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ffc1db688832fb306b884f2e216f8