### PR TITLE
Replace Avg Price with Purchase Price

### DIFF
--- a/app/financial_dashboard.html
+++ b/app/financial_dashboard.html
@@ -46,7 +46,7 @@
                                 <th></th>
                                 <th>Ticker</th>
                                 <th>Name</th>
-                                <th>Average Price</th>
+                                <th>Purchase Price</th>
                                 <th>Quantity</th>
                                 <th>Last Price</th>
                                 <th>Value</th>
@@ -100,8 +100,8 @@
                                     <input type="number" step="0.0001" id="investment-quantity" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-avg-price">Average Price</label>
-                                    <input type="number" step="0.01" id="investment-avg-price" required>
+                                    <label for="investment-purchase-price">Purchase Price</label>
+                                    <input type="number" step="0.01" id="investment-purchase-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-last-price">Last Price</label>
@@ -137,8 +137,8 @@
                                     <input type="number" step="0.0001" id="edit-quantity" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-avg-price">Average Price</label>
-                                    <input type="number" step="0.01" id="edit-avg-price" required>
+                                    <label for="edit-purchase-price">Purchase Price</label>
+                                    <input type="number" step="0.01" id="edit-purchase-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-last-price">Last Price</label>

--- a/app/index.html
+++ b/app/index.html
@@ -46,7 +46,7 @@
                                 <th></th>
                                 <th>Ticker</th>
                                 <th>Name</th>
-                                <th>Average Price</th>
+                                <th>Purchase Price</th>
                                 <th>Quantity</th>
                                 <th>Last Price</th>
                                 <th>Value</th>
@@ -100,8 +100,8 @@
                                     <input type="number" step="0.0001" id="investment-quantity" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-avg-price">Average Price</label>
-                                    <input type="number" step="0.01" id="investment-avg-price" required>
+                                    <label for="investment-purchase-price">Purchase Price</label>
+                                    <input type="number" step="0.01" id="investment-purchase-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-last-price">Last Price</label>
@@ -137,8 +137,8 @@
                                     <input type="number" step="0.0001" id="edit-quantity" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-avg-price">Average Price</label>
-                                    <input type="number" step="0.01" id="edit-avg-price" required>
+                                    <label for="edit-purchase-price">Purchase Price</label>
+                                    <input type="number" step="0.01" id="edit-purchase-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-last-price">Last Price</label>


### PR DESCRIPTION
## Summary
- rename *Average Price* to *Purchase Price* in portfolio tables and forms
- update portfolio data structure to use `purchasePrice`
- migrate old local storage data on load
- adjust UI labels and form element IDs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703a543ae0832fb51e4b6c512d7d99