### PR TITLE
Add purchase date field to portfolio

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -104,6 +104,10 @@
                                     <input type="number" step="0.01" id="investment-purchase-price" required>
                                 </div>
                                 <div class="form-group">
+                                    <label for="investment-purchase-date">Purchase Date</label>
+                                    <input type="date" id="investment-purchase-date" required>
+                                </div>
+                                <div class="form-group">
                                     <label for="investment-last-price">Last Price</label>
                                     <input type="number" step="0.01" id="investment-last-price" required>
                                 </div>
@@ -139,6 +143,10 @@
                                 <div class="form-group">
                                     <label for="edit-purchase-price">Purchase Price</label>
                                     <input type="number" step="0.01" id="edit-purchase-price" required>
+                                </div>
+                                <div class="form-group">
+                                    <label for="edit-purchase-date">Purchase Date</label>
+                                    <input type="date" id="edit-purchase-date" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-last-price">Last Price</label>


### PR DESCRIPTION
## Summary
- add Purchase Date input when adding or editing an investment
- validate purchase date and store it as `tradeDate`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703e626ca8832f9adcd6c553f2c612