### PR TITLE
Add record selection for editing investments

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -136,6 +136,10 @@
                                     <label for="edit-name">Name</label>
                                     <input type="text" id="edit-name">
                                 </div>
+                                <div class="form-group" id="edit-record-group" style="display:none;">
+                                    <label for="edit-record-select">Select Record</label>
+                                    <select id="edit-record-select"></select>
+                                </div>
                                 <div class="form-group">
                                     <label for="edit-quantity">Quantity</label>
                                     <input type="number" step="0.0001" id="edit-quantity" required>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -215,6 +215,8 @@
                 const editForm = document.getElementById('edit-investment-form');
                 const editClose = document.getElementById('edit-investment-close');
                 const editCancel = document.getElementById('edit-cancel-btn');
+                const editRecordGroup = document.getElementById("edit-record-group");
+                const editRecordSelect = document.getElementById("edit-record-select");
                 const editTotal = document.getElementById('edit-total-value');
                 let editIndex = null;
                 const API_KEY = 'd1nf8h1r01qovv8iu2dgd1nf8h1r01qovv8iu2e0';
@@ -626,9 +628,9 @@
                     }
                 }
 
-                function openEditModal(index) {
-                    editIndex = index;
-                    const inv = investments[index];
+                function populateEditFields(idx) {
+                    editIndex = idx;
+                    const inv = investments[idx];
                     document.getElementById('edit-name').value = inv.name || '';
                     document.getElementById('edit-quantity').value = inv.quantity;
                     document.getElementById('edit-purchase-price').value = inv.purchasePrice;
@@ -640,8 +642,38 @@
                     }
                     document.getElementById('edit-last-price').value = inv.lastPrice;
                     editTotal.textContent = formatCurrency(inv.quantity * inv.lastPrice);
+                }
+
+                function openEditModal(index) {
+                    const ticker = investments[index].ticker;
+                    const matches = [];
+                    investments.forEach((inv, idx) => {
+                        if (inv.ticker === ticker) matches.push(idx);
+                    });
+
+                    editRecordSelect.innerHTML = '';
+                    if (matches.length > 1) {
+                        matches.forEach(i => {
+                            const inv = investments[i];
+                            const opt = document.createElement('option');
+                            opt.value = i;
+                            opt.textContent = `${inv.quantity} @ ${formatCurrency(inv.purchasePrice)} on ${inv.tradeDate}`;
+                            editRecordSelect.appendChild(opt);
+                        });
+                        editRecordGroup.style.display = 'block';
+                        editRecordSelect.value = index;
+                        editRecordSelect.onchange = () => {
+                            const idx = parseInt(editRecordSelect.value, 10);
+                            populateEditFields(idx);
+                        };
+                    } else {
+                        editRecordGroup.style.display = 'none';
+                        editRecordSelect.onchange = null;
+                    }
+
+                    populateEditFields(index);
                     editModal.style.display = 'flex';
-                    fetchQuote(inv.ticker).then(price => {
+                    fetchQuote(ticker).then(price => {
                         if (price !== null) {
                             document.getElementById('edit-last-price').value = price;
                             handleEditInput();


### PR DESCRIPTION
## Summary
- add a record selector to the edit investment modal
- allow users to choose which investment record to edit when multiple entries share a ticker

## Testing
- `npm install --prefix app/js`
- `npm test --prefix app/js`

------
https://chatgpt.com/codex/tasks/task_e_68704e07bb04832f86b65966396741ee