### PR TITLE
Add transaction history modal

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -37,6 +37,7 @@
                     <div>
                         <button class="btn btn-primary" id="add-investment-btn">Add Investment</button>
                         <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
+                        <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
                     </div>
                 </div>
                 <div class="table-container" id="portfolio-table-container">
@@ -162,6 +163,29 @@
                                 <button type="submit" class="btn btn-primary">Save</button>
                             </div>
                         </form>
+                    </div>
+                </div>
+
+                <!-- Transaction History Modal -->
+                <div id="transaction-history-modal" class="modal">
+                    <div class="modal-content">
+                        <span class="modal-close" id="transaction-history-close">&times;</span>
+                        <h3>Transaction History</h3>
+                        <div class="table-container" style="max-height: 60vh; overflow-y: auto;">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>Ticker</th>
+                                        <th>Name</th>
+                                        <th>Quantity</th>
+                                        <th>Purchase Price</th>
+                                        <th>Last Price</th>
+                                        <th>Purchase Date</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="transaction-history-body"></tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -217,6 +217,11 @@
                 const editCancel = document.getElementById('edit-cancel-btn');
                 const editTotal = document.getElementById('edit-total-value');
                 let editIndex = null;
+
+                const historyBtn = document.getElementById('transaction-history-btn');
+                const historyModal = document.getElementById('transaction-history-modal');
+                const historyClose = document.getElementById('transaction-history-close');
+                const historyBody = document.getElementById('transaction-history-body');
                 const API_KEY = 'd1nf8h1r01qovv8iu2dgd1nf8h1r01qovv8iu2e0';
 
                 async function fetchQuote(ticker) {
@@ -654,6 +659,30 @@
                     editIndex = null;
                 }
 
+                function renderHistory() {
+                    historyBody.innerHTML = '';
+                    investments.forEach(inv => {
+                        const tr = document.createElement('tr');
+                        tr.innerHTML = `
+                            <td>${inv.ticker}</td>
+                            <td>${inv.name || ''}</td>
+                            <td class="number-cell">${inv.quantity}</td>
+                            <td class="number-cell">${formatCurrency(inv.purchasePrice)}</td>
+                            <td class="number-cell">${formatCurrency(inv.lastPrice)}</td>
+                            <td>${inv.tradeDate}</td>`;
+                        historyBody.appendChild(tr);
+                    });
+                }
+
+                function openHistoryModal() {
+                    renderHistory();
+                    historyModal.style.display = 'flex';
+                }
+
+                function closeHistoryModal() {
+                    historyModal.style.display = 'none';
+                }
+
                 function handleEditInput() {
                     const qty = parseFloat(document.getElementById('edit-quantity').value) || 0;
                     const price = parseFloat(document.getElementById('edit-last-price').value) || 0;
@@ -745,6 +774,10 @@
                     editForm.addEventListener('input', handleEditInput);
                     editForm.addEventListener('submit', saveEdit);
                     editModal.addEventListener('click', (e) => { if (e.target === editModal) closeEditModal(); });
+
+                    historyBtn.addEventListener('click', openHistoryModal);
+                    historyClose.addEventListener('click', closeHistoryModal);
+                    historyModal.addEventListener('click', (e) => { if (e.target === historyModal) closeHistoryModal(); });
 
                     renderTable();
                 }


### PR DESCRIPTION
## Summary
- add Transaction History button in portfolio section
- implement modal to display all transaction records
- wire up JavaScript logic to render and open/close the history modal

## Testing
- `npm test --prefix app/js`

------
https://chatgpt.com/codex/tasks/task_e_6870597f5714832f804ae4cee2dea0ca