### PR TITLE
Update dialog buttons to use Yes/No labels

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -569,8 +569,8 @@
                 <input type="text" id="dialog-input">
             </div>
             <div class="modal-actions">
-                <button type="button" class="btn btn-secondary" id="dialog-cancel">Cancel</button>
-                <button type="button" class="btn btn-primary" id="dialog-ok">OK</button>
+                <button type="button" class="btn btn-secondary" id="dialog-cancel">No</button>
+                <button type="button" class="btn btn-primary" id="dialog-ok">Yes</button>
             </div>
         </div>
     </div>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -19,7 +19,7 @@
                 const okBtn = document.getElementById('dialog-ok');
                 const cancelBtn = document.getElementById('dialog-cancel');
 
-                function open(type, message, def) {
+                function open(type, message, def, actionLabel) {
                     messageEl.textContent = message || '';
                     if (type === 'prompt') {
                         inputGroup.style.display = 'block';
@@ -29,6 +29,13 @@
                         inputGroup.style.display = 'none';
                     }
                     cancelBtn.style.display = type === 'alert' ? 'none' : 'inline-flex';
+                    cancelBtn.textContent = 'No';
+
+                    if (type === 'alert') {
+                        okBtn.textContent = 'Close';
+                    } else {
+                        okBtn.textContent = actionLabel ? `Yes, ${actionLabel}` : 'Yes';
+                    }
                     modal.style.display = 'flex';
 
                     return new Promise(resolve => {
@@ -56,8 +63,8 @@
 
                 return {
                     alert: msg => open('alert', msg),
-                    confirm: msg => open('confirm', msg),
-                    prompt: (msg, def) => open('prompt', msg, def)
+                    confirm: (msg, action) => open('confirm', msg, null, action),
+                    prompt: (msg, def, action) => open('prompt', msg, def, action)
                 };
             })();
 
@@ -825,7 +832,7 @@
                         openEditModal(idx);
                     } else if (btn.classList.contains('delete-btn')) {
                         const idx = parseInt(btn.dataset.index, 10);
-                        const confirmed = await DialogManager.confirm('Delete this investment?');
+                        const confirmed = await DialogManager.confirm('Delete this investment?', 'Delete');
                         if (confirmed) {
                             const removed = investments.splice(idx, 1)[0];
                             if (removed && !investments.some(inv => inv.ticker === removed.ticker)) {


### PR DESCRIPTION
## Summary
- replace `Cancel`/`OK` dialog buttons with `No` and `Yes`
- allow DialogManager to customize button labels and add `Yes, <action>` wording
- update delete confirmation to show `Yes, Delete`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870ca221ab0832fbc9f5d89554a254c