### PR TITLE
Add market status indicator

### DIFF
--- a/__tests__/css.test.js
+++ b/__tests__/css.test.js
@@ -5,4 +5,5 @@ test('style.css defines growth-positive class', () => {
   const cssPath = path.resolve(__dirname, '../app/css/style.css');
   const css = fs.readFileSync(cssPath, 'utf8');
   expect(css).toMatch(/\.growth-positive\s*\{/);
+  expect(css).toMatch(/\.led-light\s*\{/);
 });

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -19,3 +19,12 @@ test('stock chart popup includes chart controls', () => {
   expect(doc.getElementById('chart-type-price')).not.toBeNull();
   expect(doc.getElementById('chart-ticker-select')).not.toBeNull();
 });
+
+test('header contains market status indicator', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  expect(doc.getElementById('market-led')).not.toBeNull();
+  expect(doc.getElementById('market-session')).not.toBeNull();
+});

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -14,4 +14,8 @@ test('FinancialDashboard global object exists with init and removeTicker', () =>
   expect(fd).toBeDefined();
   expect(typeof fd.init).toBe('function');
   expect(typeof fd.removeTicker).toBe('function');
+
+  const ms = vm.runInContext('MarketStatus', context);
+  expect(ms).toBeDefined();
+  expect(typeof ms.init).toBe('function');
 });

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -77,6 +77,29 @@
             font-size: 1rem;
         }
 
+        .market-status {
+            margin-left: auto;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+        }
+
+        .led-light {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background-color: var(--danger-red);
+        }
+
+        .led-green {
+            background-color: var(--success-green) !important;
+        }
+
+        .led-red {
+            background-color: var(--danger-red) !important;
+        }
+
         .container {
             max-width: 1400px;
             margin: 0 auto;

--- a/app/index.html
+++ b/app/index.html
@@ -17,6 +17,10 @@
                 <h1>Financial Dashboard</h1>
                 <p>Personal Investment Tracking & Financial Planning Tool</p>
             </div>
+            <div class="market-status">
+                <span id="market-led" class="led-light led-red"></span>
+                <span id="market-session" class="market-session"></span>
+            </div>
         </div>
     </header>
 

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1787,9 +1787,47 @@
             };
         })();
 
+        // Market Status Indicator
+        const MarketStatus = (function() {
+            const API_KEY = 'd1nf8h1r01qovv8iu2dgd1nf8h1r01qovv8iu2e0';
+            const ledEl = document.getElementById('market-led');
+            const sessionEl = document.getElementById('market-session');
+
+            async function update() {
+                if (!ledEl) return;
+                try {
+                    const url = `https://finnhub.io/api/v1/market/status?exchange=US&token=${API_KEY}`;
+                    const res = await fetch(url);
+                    const data = await res.json();
+                    if (data && typeof data.isOpen === 'boolean') {
+                        ledEl.classList.toggle('led-green', data.isOpen);
+                        ledEl.classList.toggle('led-red', !data.isOpen);
+                    }
+                    if (sessionEl) {
+                        if (data && data.session) {
+                            sessionEl.textContent = data.session;
+                            sessionEl.style.display = 'inline';
+                        } else {
+                            sessionEl.textContent = '';
+                            sessionEl.style.display = 'none';
+                        }
+                    }
+                } catch (e) {
+                    // ignore errors
+                }
+            }
+
+            function init() {
+                update();
+            }
+
+            return { init };
+        })();
+
         // Initialize the application when DOM is ready
         document.addEventListener('DOMContentLoaded', function() {
             FinancialDashboard.init();
+            MarketStatus.init();
 
             const header = document.querySelector('.header');
             const nav = document.querySelector('.nav-tabs');


### PR DESCRIPTION
## Summary
- add LED indicator to header
- fetch market status from Finnhub API and update LED
- test for new LED classes and elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871104b3d84832faabc8324612c7e81