### PR TITLE
Add stock financials reports

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -283,12 +283,33 @@
             position: static;
         }
 
+        /* Make first column sticky for finance table */
+        #financials-table th:first-child,
+        #financials-table td:first-child {
+            position: sticky;
+            left: 0;
+            background: var(--background-primary);
+            z-index: 1;
+        }
+
         /* Shorten label column for finance table */
         #financials-table td:first-child {
             max-width: 150px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            font-weight: 600;
+        }
+
+        /* Header style for finance table only */
+        #financials-table th {
+            background: var(--primary-blue-dark);
+            color: #fff;
+        }
+
+        /* Negative value styling */
+        #financials-table .negative-num {
+            color: var(--danger-red);
         }
 
         /* Dedicated scroll container for the Investment Calculator table */

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -277,10 +277,10 @@
             position: relative;
         }
 
-        /* Override sticky column styles for finance table */
+        /* Override sticky column behavior for finance table */
         #financials-table th:nth-child(2),
         #financials-table td:nth-child(2) {
-            position: static;
+            left: auto; /* keep header sticky on top but not column sticky */
         }
 
         /* Make first column sticky for finance table */

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -283,6 +283,14 @@
             position: static;
         }
 
+        /* Shorten label column for finance table */
+        #financials-table td:first-child {
+            max-width: 150px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
         /* Dedicated scroll container for the Investment Calculator table */
         #investment-growth-container {
             max-height: 40vh;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -270,6 +270,19 @@
             position: relative; /* ensures sticky headers work inside */
         }
 
+        /* Dedicated scroll container for the Stock Finance table */
+        #financials-table-container {
+            max-height: 60vh;
+            overflow-y: auto;
+            position: relative;
+        }
+
+        /* Override sticky column styles for finance table */
+        #financials-table th:nth-child(2),
+        #financials-table td:nth-child(2) {
+            position: static;
+        }
+
         /* Dedicated scroll container for the Investment Calculator table */
         #investment-growth-container {
             max-height: 40vh;

--- a/app/index.html
+++ b/app/index.html
@@ -566,6 +566,14 @@
                         <label for="finance-date">Reports starting from</label>
                         <input type="date" id="finance-date" min="2011-01-01">
                     </div>
+                    <div class="form-group">
+                        <label for="finance-timeframe">Timeframe</label>
+                        <select id="finance-timeframe">
+                            <option value="quarterly">Quarterly</option>
+                            <option value="annual">Annual</option>
+                            <option value="ttm">TTM</option>
+                        </select>
+                    </div>
                     <button class="btn btn-primary" id="fetch-financials-btn">Get Reports</button>
                 </div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -569,6 +569,12 @@
                     <button class="btn btn-primary" id="fetch-financials-btn">Get Reports</button>
                 </div>
 
+                <div class="sub-nav-tabs" id="finance-subtabs">
+                    <button class="sub-nav-tab active" data-fin-subtab="income">Income Statement</button>
+                    <button class="sub-nav-tab" data-fin-subtab="balance">Balance Sheet</button>
+                    <button class="sub-nav-tab" data-fin-subtab="cash">Cash Flow</button>
+                </div>
+
                 <div class="table-container" id="financials-table-container" style="display:none;">
                     <table class="data-table" id="financials-table">
                         <thead id="financials-header"></thead>

--- a/app/index.html
+++ b/app/index.html
@@ -553,13 +553,27 @@
             
             <!-- Stock Finance Performance Tab -->
             <div id="stock-finance" class="tab-content">
-                <div class="placeholder-content">
-                    <h3>Stock Finance Performance</h3>
-                    <p>
-                        Comprehensive financial analysis and performance metrics for your stock investments. 
-                        This section will include detailed financial ratios, comparative analysis, sector performance benchmarking, 
-                        and advanced stock valuation metrics to help you make informed investment decisions.
-                    </p>
+                <div class="section-header">
+                    <h2 class="section-title">Stock Finance Performance</h2>
+                </div>
+
+                <div class="ticker-management">
+                    <div class="form-group">
+                        <label for="finance-ticker">Ticker</label>
+                        <input type="text" id="finance-ticker" style="text-transform: uppercase;">
+                    </div>
+                    <div class="form-group">
+                        <label for="finance-date">Reports starting from</label>
+                        <input type="date" id="finance-date" min="2011-01-01">
+                    </div>
+                    <button class="btn btn-primary" id="fetch-financials-btn">Get Reports</button>
+                </div>
+
+                <div class="table-container" id="financials-table-container" style="display:none;">
+                    <table class="data-table" id="financials-table">
+                        <thead id="financials-header"></thead>
+                        <tbody id="financials-body"></tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1775,6 +1775,7 @@
                 const API_KEY = 'hQmiS4FP5wJQrg8rX3gTMane2digQcLF';
                 const tickerInput = document.getElementById('finance-ticker');
                 const dateInput = document.getElementById('finance-date');
+                const timeframeSelect = document.getElementById('finance-timeframe');
                 const fetchBtn = document.getElementById('fetch-financials-btn');
                 const tableContainer = document.getElementById('financials-table-container');
                 const tableHead = document.getElementById('financials-header');
@@ -1844,8 +1845,9 @@
                 async function fetchReports() {
                     const ticker = tickerInput.value.trim().toUpperCase();
                     const date = dateInput.value;
+                    const timeframe = timeframeSelect.value || 'annual';
                     if (!ticker || !date) return;
-                    const url = `https://api.polygon.io/vX/reference/financials?ticker=${encodeURIComponent(ticker)}&filing_date.gte=${date}&limit=4&apiKey=${API_KEY}`;
+                    const url = `https://api.polygon.io/vX/reference/financials?ticker=${encodeURIComponent(ticker)}&filing_date.gte=${date}&timeframe=${timeframe}&limit=4&apiKey=${API_KEY}`;
                     try {
                         const res = await fetch(url);
                         const data = await res.json();
@@ -1934,6 +1936,7 @@
                 function init() {
                     if (!tickerInput || !fetchBtn) return;
                     setDateLimits();
+                    if (timeframeSelect && !timeframeSelect.value) timeframeSelect.value = 'annual';
                     fetchBtn.addEventListener('click', fetchReports);
                     subTabs.forEach(tab => {
                         tab.addEventListener('click', () => switchSubTab(tab.dataset.finSubtab));

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1781,6 +1781,41 @@
                 const tableBody = document.getElementById('financials-body');
                 const subTabs = document.querySelectorAll('#finance-subtabs .sub-nav-tab');
 
+                const ORDER = {
+                    income: [
+                        'revenue',
+                        'cost_of_revenue',
+                        'gross_profit',
+                        'operating_expenses',
+                        'operating_income_loss',
+                        'income_loss_before_income_tax',
+                        'income_tax_expense_benefit',
+                        'net_income_loss'
+                    ],
+                    balance: [
+                        'cash_and_cash_equivalents',
+                        'short_term_investments',
+                        'net_receivables',
+                        'inventory',
+                        'total_current_assets',
+                        'property_plant_and_equipment_net',
+                        'total_assets',
+                        'accounts_payable',
+                        'short_term_debt',
+                        'total_current_liabilities',
+                        'long_term_debt',
+                        'total_liabilities',
+                        'total_shareholders_equity',
+                        'total_liabilities_and_shareholders_equity'
+                    ],
+                    cash: [
+                        'net_cash_flow_operating',
+                        'net_cash_flow_investing',
+                        'net_cash_flow_financing',
+                        'net_cash_flow'
+                    ]
+                };
+
                 let reports = [];
                 let currentSubTab = 'income';
 
@@ -1860,14 +1895,24 @@
                         Object.keys(stmt || {}).forEach(k => allKeys.add(k));
                     });
 
-                    allKeys.forEach(k => {
+                    const orderedKeys = Array.from(allKeys).sort((a, b) => {
+                        const order = ORDER[currentSubTab] || [];
+                        const ia = order.indexOf(a);
+                        const ib = order.indexOf(b);
+                        if (ia === -1 && ib === -1) return a.localeCompare(b);
+                        if (ia === -1) return 1;
+                        if (ib === -1) return -1;
+                        return ia - ib;
+                    });
+
+                    orderedKeys.forEach(k => {
                         let label = k;
                         for (const r of reports) {
                             const item = r.financials && r.financials[statementKey] ? r.financials[statementKey][k] : undefined;
                             if (item && item.label) { label = item.label; break; }
                         }
                         const shortLabel = label.length > 20 ? label.slice(0,17) + '...' : label;
-                        let rowHtml = `<td>${shortLabel}</td>`;
+                        let rowHtml = `<td title="${label}">${shortLabel}</td>`;
                         reports.forEach(r => {
                             const item = r.financials && r.financials[statementKey] ? r.financials[statementKey][k] : undefined;
                             if (item && item.value !== undefined && item.value !== null) {

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1784,6 +1784,13 @@
                 let reports = [];
                 let currentSubTab = 'income';
 
+                function formatNumber(val) {
+                    if (val === undefined || val === null || val === '') return '';
+                    const num = Number(val);
+                    if (isNaN(num)) return val;
+                    return num.toLocaleString('en-US');
+                }
+
                 function setDateLimits() {
                     if (!dateInput) return;
                     const today = new Date().toISOString().split('T')[0];
@@ -1808,7 +1815,7 @@
                         const res = await fetch(url);
                         const data = await res.json();
                         if (data && Array.isArray(data.results) && data.results.length > 0) {
-                            reports = data.results;
+                            reports = data.results.sort((a, b) => new Date(a.filing_date) - new Date(b.filing_date));
                             renderTable();
                         } else {
                             reports = [];
@@ -1863,7 +1870,13 @@
                         let rowHtml = `<td>${shortLabel}</td>`;
                         reports.forEach(r => {
                             const item = r.financials && r.financials[statementKey] ? r.financials[statementKey][k] : undefined;
-                            rowHtml += `<td>${item ? item.value : ''}</td>`;
+                            if (item && item.value !== undefined && item.value !== null) {
+                                const formatted = formatNumber(item.value);
+                                const cls = Number(item.value) < 0 ? 'negative-num' : '';
+                                rowHtml += `<td class="${cls}">${formatted}</td>`;
+                            } else {
+                                rowHtml += '<td></td>';
+                            }
                         });
                         const tr = document.createElement('tr');
                         tr.innerHTML = rowHtml;


### PR DESCRIPTION
## Summary
- implement Stock Finance Performance feature
- fetch financial reports from Polygon API with a date filter
- show user inputs for ticker and report date
- render income statement, balance sheet and cash flow data in a table

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872306a9884832f9e214969b4fbb3a8