### PR TITLE
Fix sticky columns in Stock Finance table

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -277,17 +277,19 @@
             position: relative;
         }
 
-        /* Override sticky column behavior for finance table */
-        #financials-table th:nth-child(2),
-        #financials-table td:nth-child(2) {
-            left: auto; /* keep header sticky on top but not column sticky */
-        }
-
-        /* Make first column sticky for finance table */
+        /* Make first two columns sticky for finance table */
         #financials-table th:first-child,
         #financials-table td:first-child {
             position: sticky;
             left: 0;
+            background: var(--background-primary);
+            z-index: 2;
+        }
+
+        #financials-table th:nth-child(2),
+        #financials-table td:nth-child(2) {
+            position: sticky;
+            left: 150px; /* offset by width of label column */
             background: var(--background-primary);
             z-index: 1;
         }


### PR DESCRIPTION
## Summary
- make first two columns sticky on the Stock Finance Performance table
- adjust z-index and offset to match label width

## Testing
- `NODE_PATH=app/js/node_modules node app/js/node_modules/jest/bin/jest.js --config app/js/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_68724251d048832fac845f6b6344ad16