### PR TITLE
Improve Stock Finance tooltip

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -891,3 +891,17 @@
             width: 100%;
             height: 300px;
         }
+
+        /* Tooltip styling for finance tables */
+        .tooltip {
+            position: absolute;
+            display: none;
+            background: var(--primary-blue-dark);
+            color: #fff;
+            padding: 0.25rem 0.5rem;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            pointer-events: none;
+            z-index: 10000;
+            white-space: nowrap;
+        }

--- a/app/index.html
+++ b/app/index.html
@@ -608,6 +608,8 @@
         </div>
     </div>
 
+    <div id="tooltip" class="tooltip"></div>
+
     <script src="js/script.js"></script>
 </body>
 </html>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1781,6 +1781,7 @@
                 const tableHead = document.getElementById('financials-header');
                 const tableBody = document.getElementById('financials-body');
                 const subTabs = document.querySelectorAll('#finance-subtabs .sub-nav-tab');
+                const tooltip = document.getElementById('tooltip');
 
                 const ORDER = {
                     income: [
@@ -1819,6 +1820,30 @@
 
                 let reports = [];
                 let currentSubTab = 'income';
+
+                function setupTooltip() {
+                    if (!tooltip || !tableBody) return;
+                    tableBody.addEventListener('mouseover', (e) => {
+                        const cell = e.target.closest('.has-tooltip');
+                        if (cell) {
+                            tooltip.textContent = cell.dataset.tooltip;
+                            tooltip.style.display = 'block';
+                        }
+                    });
+                    tableBody.addEventListener('mousemove', (e) => {
+                        const cell = e.target.closest('.has-tooltip');
+                        if (cell) {
+                            tooltip.style.left = (e.pageX + 12) + 'px';
+                            tooltip.style.top = (e.pageY + 12) + 'px';
+                        }
+                    });
+                    tableBody.addEventListener('mouseout', (e) => {
+                        const cell = e.target.closest('.has-tooltip');
+                        if (cell) {
+                            tooltip.style.display = 'none';
+                        }
+                    });
+                }
 
                 function formatNumber(val) {
                     if (val === undefined || val === null || val === '') return '';
@@ -1914,7 +1939,7 @@
                             if (item && item.label) { label = item.label; break; }
                         }
                         const shortLabel = label.length > 20 ? label.slice(0,17) + '...' : label;
-                        let rowHtml = `<td title="${label}">${shortLabel}</td>`;
+                        let rowHtml = `<td class="has-tooltip" data-tooltip="${label}">${shortLabel}</td>`;
                         reports.forEach(r => {
                             const item = r.financials && r.financials[statementKey] ? r.financials[statementKey][k] : undefined;
                             if (item && item.value !== undefined && item.value !== null) {
@@ -1937,6 +1962,7 @@
                     if (!tickerInput || !fetchBtn) return;
                     setDateLimits();
                     if (timeframeSelect && !timeframeSelect.value) timeframeSelect.value = 'annual';
+                    setupTooltip();
                     fetchBtn.addEventListener('click', fetchReports);
                     subTabs.forEach(tab => {
                         tab.addEventListener('click', () => switchSubTab(tab.dataset.finSubtab));

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1823,25 +1823,17 @@
 
                 function setupTooltip() {
                     if (!tooltip || !tableBody) return;
-                    let timer = null;
-                    let lastEvent = null;
 
                     tableBody.addEventListener('mouseover', (e) => {
                         const cell = e.target.closest('.has-tooltip');
                         if (!cell) return;
-                        lastEvent = e;
-                        timer = setTimeout(() => {
-                            tooltip.textContent = cell.dataset.tooltip;
-                            tooltip.style.left = (lastEvent.pageX + 12) + 'px';
-                            tooltip.style.top = (lastEvent.pageY + 12) + 'px';
-                            tooltip.style.display = 'block';
-                        }, 2000);
+                        tooltip.textContent = cell.dataset.tooltip;
+                        tooltip.style.left = (e.pageX + 12) + 'px';
+                        tooltip.style.top = (e.pageY + 12) + 'px';
+                        tooltip.style.display = 'block';
                     });
 
                     tableBody.addEventListener('mousemove', (e) => {
-                        const cell = e.target.closest('.has-tooltip');
-                        if (!cell) return;
-                        lastEvent = e;
                         if (tooltip.style.display === 'block') {
                             tooltip.style.left = (e.pageX + 12) + 'px';
                             tooltip.style.top = (e.pageY + 12) + 'px';
@@ -1851,8 +1843,6 @@
                     tableBody.addEventListener('mouseout', (e) => {
                         const cell = e.target.closest('.has-tooltip');
                         if (!cell) return;
-                        clearTimeout(timer);
-                        timer = null;
                         tooltip.style.display = 'none';
                     });
                 }

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1823,25 +1823,37 @@
 
                 function setupTooltip() {
                     if (!tooltip || !tableBody) return;
+                    let timer = null;
+                    let lastEvent = null;
+
                     tableBody.addEventListener('mouseover', (e) => {
                         const cell = e.target.closest('.has-tooltip');
-                        if (cell) {
+                        if (!cell) return;
+                        lastEvent = e;
+                        timer = setTimeout(() => {
                             tooltip.textContent = cell.dataset.tooltip;
+                            tooltip.style.left = (lastEvent.pageX + 12) + 'px';
+                            tooltip.style.top = (lastEvent.pageY + 12) + 'px';
                             tooltip.style.display = 'block';
-                        }
+                        }, 2000);
                     });
+
                     tableBody.addEventListener('mousemove', (e) => {
                         const cell = e.target.closest('.has-tooltip');
-                        if (cell) {
+                        if (!cell) return;
+                        lastEvent = e;
+                        if (tooltip.style.display === 'block') {
                             tooltip.style.left = (e.pageX + 12) + 'px';
                             tooltip.style.top = (e.pageY + 12) + 'px';
                         }
                     });
+
                     tableBody.addEventListener('mouseout', (e) => {
                         const cell = e.target.closest('.has-tooltip');
-                        if (cell) {
-                            tooltip.style.display = 'none';
-                        }
+                        if (!cell) return;
+                        clearTimeout(timer);
+                        timer = null;
+                        tooltip.style.display = 'none';
                     });
                 }
 


### PR DESCRIPTION
## Summary
- add tooltip element to the page
- style tooltip with finance theme colors
- display custom tooltip in Stock Finance table

## Testing
- `cd app/js && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687251c7f368832f989d892c635cdfed