### PR TITLE
Add early and after hours LEDs

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -27,4 +27,6 @@ test('header contains market status indicator', () => {
   const doc = dom.window.document;
   expect(doc.getElementById('market-led')).not.toBeNull();
   expect(doc.getElementById('market-session')).not.toBeNull();
+  expect(doc.getElementById('early-led')).not.toBeNull();
+  expect(doc.getElementById('after-led')).not.toBeNull();
 });

--- a/app/index.html
+++ b/app/index.html
@@ -21,6 +21,12 @@
                 <span>Market status</span>
                 <span id="market-led" class="led-light led-red"></span>
                 <span id="market-session" class="market-session"></span>
+                <span>Early</span>
+                <span id="early-led" class="led-light led-red"></span>
+                <span id="early-session" class="market-session"></span>
+                <span>After</span>
+                <span id="after-led" class="led-light led-red"></span>
+                <span id="after-session" class="market-session"></span>
             </div>
         </div>
     </header>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -2111,6 +2111,10 @@
             const API_KEY = 'hQmiS4FP5wJQrg8rX3gTMane2digQcLF';
             const ledEl = document.getElementById('market-led');
             const sessionEl = document.getElementById('market-session');
+            const earlyLedEl = document.getElementById('early-led');
+            const earlySessionEl = document.getElementById('early-session');
+            const afterLedEl = document.getElementById('after-led');
+            const afterSessionEl = document.getElementById('after-session');
             let timer = null;
 
             async function update() {
@@ -2120,8 +2124,18 @@
                     const res = await fetch(url);
                     const data = await res.json();
                     const isOpen = data && data.market === 'open';
+                    const earlyOpen = data && data.earlyHours === true;
+                    const afterOpen = data && data.afterHours === true;
                     ledEl.classList.toggle('led-green', isOpen);
                     ledEl.classList.toggle('led-red', !isOpen);
+                    if (earlyLedEl) {
+                        earlyLedEl.classList.toggle('led-green', earlyOpen);
+                        earlyLedEl.classList.toggle('led-red', !earlyOpen);
+                    }
+                    if (afterLedEl) {
+                        afterLedEl.classList.toggle('led-green', afterOpen);
+                        afterLedEl.classList.toggle('led-red', !afterOpen);
+                    }
                     if (sessionEl) {
                         if (data && data.market) {
                             sessionEl.textContent = data.market;
@@ -2130,6 +2144,12 @@
                             sessionEl.textContent = '';
                             sessionEl.style.display = 'none';
                         }
+                    }
+                    if (earlySessionEl) {
+                        earlySessionEl.textContent = earlyOpen ? 'open' : 'closed';
+                    }
+                    if (afterSessionEl) {
+                        afterSessionEl.textContent = afterOpen ? 'open' : 'closed';
                     }
                 } catch (e) {
                     // ignore errors


### PR DESCRIPTION
## Summary
- add early and after hours indicators in header
- expand MarketStatus to update new LEDs
- test for presence of new LED elements in HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872e7e88164832f8e628a3c3dabf268