### PR TITLE
Arrange market status rows

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -80,9 +80,16 @@
         .market-status {
             margin-left: auto;
             display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 0.25rem;
+            font-size: 0.9rem;
+        }
+
+        .status-row {
+            display: flex;
             align-items: center;
             gap: 0.5rem;
-            font-size: 0.9rem;
         }
 
         .led-light {

--- a/app/index.html
+++ b/app/index.html
@@ -18,15 +18,21 @@
                 <p>Personal Investment Tracking & Financial Planning Tool</p>
             </div>
             <div class="market-status">
-                <span>Pre Market</span>
-                <span id="early-led" class="led-light led-red"></span>
-                <span id="early-session" class="market-session"></span>
-                <span>Market status</span>
-                <span id="market-led" class="led-light led-red"></span>
-                <span id="market-session" class="market-session"></span>
-                <span>After Market</span>
-                <span id="after-led" class="led-light led-red"></span>
-                <span id="after-session" class="market-session"></span>
+                <div class="status-row">
+                    <span>Pre Market</span>
+                    <span id="early-led" class="led-light led-red"></span>
+                    <span id="early-session" class="market-session"></span>
+                </div>
+                <div class="status-row">
+                    <span>Market status</span>
+                    <span id="market-led" class="led-light led-red"></span>
+                    <span id="market-session" class="market-session"></span>
+                </div>
+                <div class="status-row">
+                    <span>After Market</span>
+                    <span id="after-led" class="led-light led-red"></span>
+                    <span id="after-session" class="market-session"></span>
+                </div>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- show each market session on its own row
- style new `.status-row` blocks in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872eddf92ec832f98286d00c6b36c3e