### PR TITLE
Add news modal to portfolio

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -922,3 +922,20 @@
             z-index: 10000;
             white-space: nowrap;
         }
+
+        /* News Modal Articles */
+        #news-content article {
+            margin-bottom: 1.5rem;
+        }
+
+        #news-content h3 {
+            font-size: 1.2rem;
+            margin-bottom: 0.5rem;
+            color: var(--primary-blue);
+        }
+
+        #news-content img {
+            max-width: 100%;
+            height: auto;
+            margin: 0.5rem 0;
+        }

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -923,6 +923,12 @@
             white-space: nowrap;
         }
 
+        /* News Modal Container */
+        #news-content {
+            max-height: 60vh;
+            overflow-y: auto;
+        }
+
         /* News Modal Articles */
         #news-content article {
             margin-bottom: 1.5rem;

--- a/app/index.html
+++ b/app/index.html
@@ -216,7 +216,7 @@
                 <div id="news-modal" class="modal">
                     <div class="modal-content">
                         <span class="modal-close" id="news-close">&times;</span>
-                        <div id="news-content" style="max-height: 60vh; overflow-y: auto;"></div>
+                        <div id="news-content"></div>
                     </div>
                 </div>
             </div>

--- a/app/index.html
+++ b/app/index.html
@@ -33,6 +33,7 @@
                     <span id="after-led" class="led-light led-red"></span>
                     <span id="after-session" class="market-session"></span>
                 </div>
+
             </div>
         </div>
     </header>
@@ -55,6 +56,7 @@
                         <button class="btn btn-primary" id="add-investment-btn">Add Investment</button>
                         <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
                         <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
+                        <button class="btn btn-secondary" id="news-btn">News</button>
                     </div>
                 </div>
                 <div class="table-container" id="portfolio-table-container">
@@ -207,6 +209,14 @@
                                 <tbody id="transaction-history-body"></tbody>
                             </table>
                         </div>
+                    </div>
+                </div>
+
+                <!-- News Modal -->
+                <div id="news-modal" class="modal">
+                    <div class="modal-content">
+                        <span class="modal-close" id="news-close">&times;</span>
+                        <div id="news-content" style="max-height: 60vh; overflow-y: auto;"></div>
                     </div>
                 </div>
             </div>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -780,7 +780,7 @@
                     historyModal.style.display = 'none';
                 }
 
-                async function fetchNewsArticle(ticker) {
+                async function fetchNewsArticles(ticker) {
                     const today = new Date();
                     const to = today.toISOString().split('T')[0];
                     const from = new Date(today.getTime() - 86400000).toISOString().split('T')[0];
@@ -788,22 +788,27 @@
                     try {
                         const res = await fetch(url);
                         const data = await res.json();
-                        if (Array.isArray(data) && data.length > 0) {
-                            return data[0];
+                        if (Array.isArray(data)) {
+                            return data;
                         }
                     } catch (e) {
                         // ignore errors
                     }
-                    return null;
+                    return [];
                 }
 
                 async function openNewsModal() {
                     newsContent.innerHTML = '<p>Loading...</p>';
                     newsModal.style.display = 'flex';
                     const tickers = [...new Set(investments.map(inv => inv.ticker))];
-                    const articles = await Promise.all(tickers.map(fetchNewsArticle));
+                    const results = await Promise.all(tickers.map(fetchNewsArticles));
+                    const articles = results.flat();
                     newsContent.innerHTML = '';
-                    articles.filter(a => a).forEach(article => {
+                    if (articles.length === 0) {
+                        newsContent.textContent = 'No news found.';
+                        return;
+                    }
+                    articles.forEach(article => {
                         const art = document.createElement('article');
                         const title = document.createElement('h3');
                         title.textContent = article.headline;
@@ -811,7 +816,7 @@
                         if (article.image) {
                             const img = document.createElement('img');
                             img.src = article.image;
-                            img.alt = '';
+                            img.alt = article.headline;
                             art.appendChild(img);
                         }
                         const text = document.createElement('p');


### PR DESCRIPTION
## Summary
- add a News button to the portfolio header
- show a modal with latest company news for portfolio tickers
- style news articles in modal

## Testing
- `npm --prefix app/js install`
- `npx --prefix app/js jest --config app/js/jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_6872f5cefce4832f9e1314f999892eeb