### PR TITLE
Adjust finance value display

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -284,6 +284,12 @@
             position: relative;
         }
 
+        #finance-zero-info {
+            margin: 0.5rem 0;
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+        }
+
         /* Make first two columns sticky for finance table */
         #financials-table th:first-child {
             position: sticky;

--- a/app/index.html
+++ b/app/index.html
@@ -596,6 +596,8 @@
                     <button class="sub-nav-tab" data-fin-subtab="stats">Statistics</button>
                 </div>
 
+                <div id="finance-zero-info" class="zero-info" style="display:none;"></div>
+
                 <div class="table-container" id="financials-table-container" style="display:none;">
                     <table class="data-table" id="financials-table">
                         <thead id="financials-header"></thead>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1906,7 +1906,14 @@
                     if (val === undefined || val === null || val === '') return '';
                     const num = Number(val);
                     if (isNaN(num)) return val;
-                    return num.toLocaleString('en-US');
+                    let formatted = num.toLocaleString('en-US');
+                    if (formatted.endsWith('000,000')) {
+                        formatted = formatted.slice(0, -8);
+                        if (formatted.endsWith(',')) {
+                            formatted = formatted.slice(0, -1);
+                        }
+                    }
+                    return formatted;
                 }
 
                 function getValue(obj, paths) {

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1783,6 +1783,7 @@
                 const tableBody = document.getElementById('financials-body');
                 const subTabs = document.querySelectorAll('#finance-subtabs .sub-nav-tab');
                 const tooltip = document.getElementById('tooltip');
+                const zeroInfoEl = document.getElementById('finance-zero-info');
 
                 const ORDER = {
                     ic: [
@@ -1902,6 +1903,12 @@
                     });
                 }
 
+                function showZeroInfo() {
+                    if (!zeroInfoEl) return;
+                    zeroInfoEl.textContent = 'Values trimmed by removing 6 trailing zeros ("000,000")';
+                    zeroInfoEl.style.display = 'block';
+                }
+
                 function formatNumber(val) {
                     if (val === undefined || val === null || val === '') return '';
                     const num = Number(val);
@@ -2007,18 +2014,21 @@
 
                             currentTicker = ticker;
                             currentSharePrice = await PortfolioManager.fetchQuote(ticker);
+                            showZeroInfo();
                             renderTable();
                         } else {
                             reports = [];
                             tableHead.innerHTML = '';
                             tableBody.innerHTML = '<tr><td>No data available</td></tr>';
                             tableContainer.style.display = 'block';
+                            if (zeroInfoEl) zeroInfoEl.style.display = 'none';
                         }
                     } catch (e) {
                         reports = [];
                         tableHead.innerHTML = '';
                         tableBody.innerHTML = '<tr><td>Failed to load data</td></tr>';
                         tableContainer.style.display = 'block';
+                        if (zeroInfoEl) zeroInfoEl.style.display = 'none';
                     }
                 }
 


### PR DESCRIPTION
## Summary
- shorten large finance numbers by trimming trailing `000,000` in Stock Finance Performance

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873b1b3a258832fbd49a38680f146a5