### PR TITLE
Trim year to last two digits

### DIFF
--- a/app/js/script.js
+++ b/app/js/script.js
@@ -2051,7 +2051,8 @@
                     reports.forEach(r => {
                         const yr = r.fiscal_year || '';
                         const period = r.fiscal_period || '';
-                        headerHtml += `<th>${yr} ${period}</th>`;
+                        const shortYr = yr ? yr.toString().slice(-2) : '';
+                        headerHtml += `<th>${shortYr} ${period}</th>`;
                     });
                     headerRow.innerHTML = headerHtml;
                     tableHead.appendChild(headerRow);


### PR DESCRIPTION
## Summary
- shorten fiscal year display in Stock Finance Performance table header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873cc476b38832fa47271c9334f8bbc