### PR TITLE
Add responsive actions menu

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -765,6 +765,7 @@
         }
 
         .action-buttons {
+            display: none;
             position: absolute;
             top: 100%;
             right: 0;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -183,6 +183,22 @@
             margin-bottom: 1.5rem;
         }
 
+        .portfolio-actions {
+            position: relative;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .action-buttons {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .menu-toggle {
+            display: none;
+        }
+
         .price-input[readonly] {
             border: none;
             background: transparent;
@@ -746,6 +762,28 @@
             text-decoration: underline;
             padding: 0.25rem 0.5rem;
             font-size: 1rem;
+        }
+
+        .action-buttons {
+            position: absolute;
+            top: 100%;
+            right: 0;
+            background: var(--background-primary);
+            flex-direction: column;
+            padding: 0.5rem;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+            width: max-content;
+            z-index: 100;
+        }
+
+        .action-buttons.open {
+            display: flex;
+        }
+
+        .menu-toggle {
+            display: inline-flex;
         }
 
         }

--- a/app/index.html
+++ b/app/index.html
@@ -51,10 +51,15 @@
             <div id="portfolio" class="tab-content active">
                 <div class="section-header">
                     <h2 class="section-title">Portfolio</h2>
-                    <div>
-                        <button class="btn btn-primary" id="add-investment-btn">Add Investment</button>
-                        <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
-                        <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
+                    <div class="portfolio-actions">
+                        <div id="portfolio-actions-menu" class="action-buttons">
+                            <button class="btn btn-primary" id="add-investment-btn">Add Investment</button>
+                            <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
+                            <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
+                        </div>
+                        <button class="icon-btn menu-toggle" id="portfolio-menu-toggle" aria-label="More actions">
+                            <ion-icon name="ellipsis-vertical"></ion-icon>
+                        </button>
                     </div>
                 </div>
                 <div class="table-container" id="portfolio-table-container">

--- a/app/index.html
+++ b/app/index.html
@@ -52,12 +52,12 @@
                 <div class="section-header">
                     <h2 class="section-title">Portfolio</h2>
                     <div class="portfolio-actions">
-                        <div id="portfolio-actions-menu" class="action-buttons">
+                        <div id="portfolio-actions-menu" class="action-buttons" role="menu">
                             <button class="btn btn-primary" id="add-investment-btn">Add Investment</button>
                             <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
                             <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
                         </div>
-                        <button class="icon-btn menu-toggle" id="portfolio-menu-toggle" aria-label="More actions">
+                        <button class="icon-btn menu-toggle" id="portfolio-menu-toggle" aria-label="More actions" aria-expanded="false" aria-controls="portfolio-actions-menu">
                             <ion-icon name="ellipsis-vertical"></ion-icon>
                         </button>
                     </div>

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -877,7 +877,15 @@
 
                     menuToggle.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        actionsMenu.classList.toggle('open');
+                        const expanded = actionsMenu.classList.toggle('open');
+                        menuToggle.setAttribute('aria-expanded', expanded);
+                    });
+
+                    actionsMenu.addEventListener('click', (e) => {
+                        if (e.target.closest('button')) {
+                            actionsMenu.classList.remove('open');
+                            menuToggle.setAttribute('aria-expanded', 'false');
+                        }
                     });
 
                     document.addEventListener('click', (e) => {
@@ -885,6 +893,7 @@
                             !actionsMenu.contains(e.target) &&
                             e.target !== menuToggle) {
                             actionsMenu.classList.remove('open');
+                            menuToggle.setAttribute('aria-expanded', 'false');
                         }
                     });
 

--- a/app/js/script.js
+++ b/app/js/script.js
@@ -285,6 +285,8 @@
                 const historyModal = document.getElementById('transaction-history-modal');
                 const historyClose = document.getElementById('transaction-history-close');
                 const historyBody = document.getElementById('transaction-history-body');
+                const menuToggle = document.getElementById('portfolio-menu-toggle');
+                const actionsMenu = document.getElementById('portfolio-actions-menu');
                 const API_KEY = 'd1nf8h1r01qovv8iu2dgd1nf8h1r01qovv8iu2e0';
 
                 async function fetchQuote(ticker) {
@@ -872,6 +874,19 @@
                     historyBtn.addEventListener('click', openHistoryModal);
                     historyClose.addEventListener('click', closeHistoryModal);
                     historyModal.addEventListener('click', (e) => { if (e.target === historyModal) closeHistoryModal(); });
+
+                    menuToggle.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        actionsMenu.classList.toggle('open');
+                    });
+
+                    document.addEventListener('click', (e) => {
+                        if (actionsMenu.classList.contains('open') &&
+                            !actionsMenu.contains(e.target) &&
+                            e.target !== menuToggle) {
+                            actionsMenu.classList.remove('open');
+                        }
+                    });
 
                     renderTable();
                 }


### PR DESCRIPTION
## Summary
- add actions menu HTML for portfolio tab
- style menu and hide on desktop
- implement toggle logic for mobile menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882979d9f00832faabec973437b5387