### PR TITLE
Fix mobile menu toggle visibility

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -966,4 +966,15 @@
             pointer-events: none;
             z-index: 10000;
             white-space: nowrap;
+}
+
+        /* Hide portfolio menu toggle on large screens */
+        .icon-btn.menu-toggle {
+            display: none;
+        }
+
+        @media (max-width: 768px) {
+            .icon-btn.menu-toggle {
+                display: inline-flex;
+            }
         }


### PR DESCRIPTION
## Summary
- ensure three-dot menu for portfolio actions only displays on small screens

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a8483538832f8d381c71a1cb2c4e