### PR TITLE
Optimize price fetch calls

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -141,6 +141,12 @@ Creates a Chart.js chart for portfolio visualization.
 
 **Returns:** `Chart` - Chart.js instance
 
+##### `fetchLastPrices()`
+Fetches the latest price for each unique ticker in the portfolio.
+
+**Returns:** `Promise<void>`
+
+
 ---
 
 ### Calculator


### PR DESCRIPTION
## Summary
- deduplicate ticker requests in PortfolioManager
- export `fetchLastPrices` for external usage
- document `fetchLastPrices` in API reference

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885556fd648832f814cfa3e5e164e0a