### PR TITLE
Add multiple portfolio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Personal Finance Dashboard is designed as a single HTML file application tha
 ## Features
 
 ### 📊 Portfolio Management
+- Manage multiple portfolios with a combined summary view
 - Add, edit, and delete investment positions with detailed tracking
 - Real-time profit/loss calculations with percentage gains/losses
 - Interactive charts showing portfolio allocation and performance
@@ -106,10 +107,11 @@ For contributors and developers:
 
 ### Portfolio Management
 1. Navigate to the "Portfolio" tab
-2. Click "Add Investment" to create new positions
-3. Enter stock symbol, quantity, and purchase price
-4. Adding a ticker that already exists prompts you to combine the positions
-5. View real-time calculations and charts
+2. Use "Add Portfolio" to create additional portfolios as needed
+3. Click "Add Investment" to create new positions within the selected portfolio
+4. Enter stock symbol, quantity, and purchase price
+5. Adding a ticker that already exists prompts you to combine the positions
+6. View real-time calculations and charts
 
 ### Using Calculators
 1. Go to the "Calculators" tab

--- a/RULES.md
+++ b/RULES.md
@@ -8,6 +8,7 @@ This file outlines basic rules and coding standards for the Personal Finance Das
 - Run `npm install` inside `app/js` before running tests.
 - Keep documentation up to date with code changes.
 - Respect the `.gitignore` settings; do not commit dependencies or local build artifacts.
+- Use the built-in `DialogManager` for all alerts, prompts, and confirmation dialogs.
 
 ## Community Standards
 - Be respectful and collaborative.

--- a/app/index.html
+++ b/app/index.html
@@ -56,12 +56,15 @@
                             <button class="btn btn-primary" id="add-investment-btn">Add Investment</button>
                             <button class="btn btn-secondary" id="get-last-price-btn">Get The Last Price</button>
                             <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
+                            <button class="btn btn-secondary" id="add-portfolio-btn">Add Portfolio</button>
+                            <button class="btn btn-secondary" id="remove-portfolio-btn">Remove Portfolio</button>
                         </div>
                         <button class="icon-btn menu-toggle" id="portfolio-menu-toggle" aria-label="More actions" aria-expanded="false" aria-controls="portfolio-actions-menu">
                             <ion-icon name="ellipsis-vertical"></ion-icon>
                         </button>
                     </div>
                 </div>
+                <div id="portfolio-tabs" class="sub-nav-tabs"></div>
                 <div class="table-container" id="portfolio-table-container">
                     <table class="data-table" id="portfolio-table">
                         <thead>

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -237,8 +237,8 @@ const PortfolioManager = (function() {
         getPriceBtn.style.display = summaryMode ? 'none' : 'inline-flex';
     }
 
-    function addPortfolio() {
-        const name = prompt('Portfolio name?');
+    async function addPortfolio() {
+        const name = await DialogManager.prompt('Enter portfolio name:', '');
         if (!name) return;
         const id = 'pf' + Date.now();
         portfolios.push({ id, name });


### PR DESCRIPTION
## Summary
- allow creating/removing multiple portfolios
- show portfolio selector tabs and summary
- hide editing when viewing summary

## Testing
- `npm install` inside `app/js`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68855cb3c078832fac74111b2d7def05