### PR TITLE
Add currency support for portfolio quotes

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -30,3 +30,12 @@ test('header contains market status indicator', () => {
   expect(doc.getElementById('early-led')).not.toBeNull();
   expect(doc.getElementById('after-led')).not.toBeNull();
 });
+
+test('portfolio table includes currency column', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const headers = Array.from(doc.querySelectorAll('#portfolio-table thead th')).map(th => th.textContent.trim());
+  expect(headers).toContain('Currency');
+});

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -39,3 +39,18 @@ test('portfolio table includes currency column', () => {
   const headers = Array.from(doc.querySelectorAll('#portfolio-table thead th')).map(th => th.textContent.trim());
   expect(headers).toContain('Currency');
 });
+
+test('investment forms allow selecting currency', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const addSelect = doc.getElementById('investment-currency');
+  const editSelect = doc.getElementById('edit-currency');
+  expect(addSelect.tagName).toBe('SELECT');
+  expect(editSelect.tagName).toBe('SELECT');
+  const addOptions = Array.from(addSelect.querySelectorAll('option')).map(o => o.value);
+  const editOptions = Array.from(editSelect.querySelectorAll('option')).map(o => o.value);
+  expect(addOptions).toEqual(expect.arrayContaining(['USD', 'GBP']));
+  expect(editOptions).toEqual(expect.arrayContaining(['USD', 'GBP']));
+});

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -31,3 +31,15 @@ test('FinancialDashboard global object exists with init and removeTicker', () =>
   expect(ms).toBeDefined();
   expect(typeof ms.init).toBe('function');
 });
+
+test('fetchQuote returns price and currency', async () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {url: 'http://localhost'});
+  const context = vm.createContext(dom.window);
+  dom.window.fetch = jest.fn().mockResolvedValue({
+    json: () => Promise.resolve({ c: 123.45, currency: 'EUR' })
+  });
+  const content = fs.readFileSync(path.resolve(__dirname, '../app/js/portfolioManager.js'), 'utf8');
+  vm.runInContext(content, context);
+  const result = await vm.runInContext('PortfolioManager.fetchQuote("TEST")', context);
+  expect(result).toEqual({ price: 123.45, currency: 'EUR' });
+});

--- a/app/index.html
+++ b/app/index.html
@@ -71,6 +71,7 @@
                             <tr>
                                 <th></th>
                                 <th>Ticker</th>
+                                <th>Currency</th>
                                 <th>Name</th>
                                 <th>Purchase Price</th>
                                 <th>Quantity</th>
@@ -85,7 +86,7 @@
                         <tfoot>
                             <tr class="summary-row">
                                 <td></td>
-                                <td colspan="5">Total</td>
+                                <td colspan="6">Total</td>
                                 <td id="portfolio-total-value" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-pl" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-plpct" class="number-cell">0.00%</td>
@@ -138,6 +139,10 @@
                                     <input type="number" step="0.01" id="investment-last-price" required>
                                 </div>
                                 <div class="form-group">
+                                    <label for="investment-currency">Currency</label>
+                                    <input type="text" id="investment-currency" readonly>
+                                </div>
+                                <div class="form-group">
                                     <label>Total Value</label>
                                     <span id="investment-total-value">$0.00</span>
                                 </div>
@@ -183,6 +188,10 @@
                                     <input type="number" step="0.01" id="edit-last-price" required>
                                 </div>
                                 <div class="form-group">
+                                    <label for="edit-currency">Currency</label>
+                                    <input type="text" id="edit-currency" readonly>
+                                </div>
+                                <div class="form-group">
                                     <label>Total Value</label>
                                     <span id="edit-total-value">$0.00</span>
                                 </div>
@@ -205,6 +214,7 @@
                                 <thead>
                                     <tr>
                                         <th>Ticker</th>
+                                        <th>Currency</th>
                                         <th>Name</th>
                                         <th>Quantity</th>
                                         <th>Purchase Price</th>

--- a/app/index.html
+++ b/app/index.html
@@ -140,7 +140,10 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-currency">Currency</label>
-                                    <input type="text" id="investment-currency" readonly>
+                                    <select id="investment-currency">
+                                        <option value="USD">USD</option>
+                                        <option value="GBP">GBP</option>
+                                    </select>
                                 </div>
                                 <div class="form-group">
                                     <label>Total Value</label>
@@ -189,7 +192,10 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-currency">Currency</label>
-                                    <input type="text" id="edit-currency" readonly>
+                                    <select id="edit-currency">
+                                        <option value="USD">USD</option>
+                                        <option value="GBP">GBP</option>
+                                    </select>
                                 </div>
                                 <div class="form-group">
                                     <label>Total Value</label>

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -48,18 +48,18 @@ const PortfolioManager = (function() {
     const actionsMenu = document.getElementById('portfolio-actions-menu');
     const API_KEY = 'd1nf8h1r01qovv8iu2dgd1nf8h1r01qovv8iu2e0';
 
-    async function fetchQuote(ticker) {
-        const url = `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(ticker)}&token=${API_KEY}`;
+    async function fetchQuote(ticker, currency = 'USD') {
+        const url = `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(ticker)}&token=${API_KEY}&currency=${encodeURIComponent(currency)}`;
         try {
             const res = await fetch(url);
             const data = await res.json();
             if (data && typeof data.c === 'number') {
-                return parseFloat(data.c);
+                return { price: parseFloat(data.c), currency: data.currency || currency };
             }
         } catch (e) {
             // ignore errors and return null
         }
-        return null;
+        return { price: null, currency };
     }
 
     async function lookupSymbol(ticker) {
@@ -140,6 +140,10 @@ const PortfolioManager = (function() {
                     inv.tradeDate = new Date().toISOString().split('T')[0];
                     migrated = true;
                 }
+                if (!inv.currency) {
+                    inv.currency = 'USD';
+                    migrated = true;
+                }
             });
             if (migrated && !summaryMode) {
                 localStorage.setItem(getStorageKey(currentPortfolioId), JSON.stringify(investments));
@@ -168,8 +172,8 @@ const PortfolioManager = (function() {
         localStorage.setItem(COLOR_KEY, JSON.stringify(tickerColors));
     }
 
-    function formatCurrency(value) {
-        return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+    function formatCurrency(value, currency = 'USD') {
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value);
     }
 
     function updateTotals() {
@@ -383,10 +387,11 @@ const PortfolioManager = (function() {
             row.innerHTML = `
                 <td class="drag-handle-cell"><ion-icon name="reorder-three-outline"></ion-icon></td>
                 <td>${inv.ticker}</td>
+                <td>${inv.currency || ''}</td>
                 <td>${inv.name}</td>
-                <td class="number-cell">${formatCurrency(inv.purchasePrice)}</td>
+                <td class="number-cell">${formatCurrency(inv.purchasePrice, inv.currency)}</td>
                 <td class="number-cell">${inv.quantity}</td>
-                <td class="number-cell">${formatCurrency(inv.lastPrice)}</td>
+                <td class="number-cell">${formatCurrency(inv.lastPrice, inv.currency)}</td>
                 <td class="value-cell"></td>
                 <td class="pl-cell"></td>
                 <td class="plpct-cell"></td>
@@ -416,8 +421,8 @@ const PortfolioManager = (function() {
             const pl = value - cost;
             const plPct = cost ? (pl / cost) * 100 : 0;
 
-            row.querySelector('.value-cell').textContent = formatCurrency(value);
-            row.querySelector('.pl-cell').textContent = formatCurrency(pl);
+            row.querySelector('.value-cell').textContent = formatCurrency(value, inv.currency);
+            row.querySelector('.pl-cell').textContent = formatCurrency(pl, inv.currency);
             row.querySelector('.pl-cell').className = 'pl-cell ' + (pl >= 0 ? 'growth-positive' : 'growth-negative');
             row.querySelector('.plpct-cell').textContent = plPct.toFixed(2) + '%';
             row.querySelector('.plpct-cell').className = 'plpct-cell ' + (plPct >= 0 ? 'growth-positive' : 'growth-negative');
@@ -479,7 +484,8 @@ const PortfolioManager = (function() {
     function handleFormInput() {
         const qty = parseFloat(document.getElementById('investment-quantity').value) || 0;
         const lastPrice = parseFloat(document.getElementById('investment-last-price').value) || 0;
-        totalDisplay.textContent = formatCurrency(qty * lastPrice);
+        const currency = document.getElementById('investment-currency').value || 'USD';
+        totalDisplay.textContent = formatCurrency(qty * lastPrice, currency);
     }
 
     async function handleTickerLookup() {
@@ -488,7 +494,7 @@ const PortfolioManager = (function() {
             tickerValid = false;
             return;
         }
-        const [price, description] = await Promise.all([
+        const [{ price, currency }, description] = await Promise.all([
             fetchQuote(ticker),
             lookupSymbol(ticker)
         ]);
@@ -502,11 +508,13 @@ const PortfolioManager = (function() {
             DialogManager.alert('Ticker symbol does not exist');
         }
 
+        const lastPriceEl = document.getElementById('investment-last-price');
+        const currencyEl = document.getElementById('investment-currency');
         if (price !== null) {
-            const lastPriceEl = document.getElementById('investment-last-price');
             lastPriceEl.value = price;
-            handleFormInput();
         }
+        if (currencyEl) currencyEl.value = currency || 'USD';
+        handleFormInput();
     }
 
     function addFromForm(resetAfter) {
@@ -517,6 +525,7 @@ const PortfolioManager = (function() {
         const purchasePrice = parseFloat(document.getElementById('investment-purchase-price').value) || 0;
         const purchaseDate = document.getElementById('investment-purchase-date').value;
         const lastPrice = parseFloat(document.getElementById('investment-last-price').value) || 0;
+        const currency = document.getElementById('investment-currency').value || 'USD';
         if (!tickerValid) {
             DialogManager.alert('Please enter a valid ticker symbol.');
             return;
@@ -530,7 +539,7 @@ const PortfolioManager = (function() {
 
 
         assignColor(ticker);
-        investments.push({ ticker, name, quantity, purchasePrice, lastPrice, tradeDate: purchaseDate });
+        investments.push({ ticker, name, quantity, purchasePrice, lastPrice, tradeDate: purchaseDate, currency });
         saveData();
         renderTable();
 
@@ -541,7 +550,7 @@ const PortfolioManager = (function() {
                 dateField.value = today;
                 dateField.max = today;
             }
-            totalDisplay.textContent = formatCurrency(0);
+            totalDisplay.textContent = formatCurrency(0, 'USD');
             document.getElementById('investment-ticker').focus();
         } else {
             closeModal();
@@ -561,7 +570,9 @@ const PortfolioManager = (function() {
             dateField.value = inv.tradeDate || today;
         }
         document.getElementById('edit-last-price').value = inv.lastPrice;
-        editTotal.textContent = formatCurrency(inv.quantity * inv.lastPrice);
+        const currencyField = document.getElementById('edit-currency');
+        if (currencyField) currencyField.value = inv.currency || 'USD';
+        editTotal.textContent = formatCurrency(inv.quantity * inv.lastPrice, inv.currency);
     }
 
     function openEditModal(index) {
@@ -578,7 +589,7 @@ const PortfolioManager = (function() {
                 const inv = investments[i];
                 const opt = document.createElement('option');
                 opt.value = i;
-                opt.textContent = `${inv.quantity} @ ${formatCurrency(inv.purchasePrice)} on ${inv.tradeDate}`;
+                opt.textContent = `${inv.quantity} @ ${formatCurrency(inv.purchasePrice, inv.currency)} on ${inv.tradeDate}`;
                 editRecordSelect.appendChild(opt);
             });
             editRecordGroup.style.display = 'block';
@@ -594,11 +605,13 @@ const PortfolioManager = (function() {
 
         populateEditFields(index);
         editModal.style.display = 'flex';
-        fetchQuote(ticker).then(price => {
-            if (price !== null) {
-                document.getElementById('edit-last-price').value = price;
-                handleEditInput();
+        fetchQuote(ticker, investments[index].currency || 'USD').then(res => {
+            if (res.price !== null) {
+                document.getElementById('edit-last-price').value = res.price;
             }
+            const currencyField = document.getElementById('edit-currency');
+            if (currencyField) currencyField.value = res.currency || 'USD';
+            handleEditInput();
         });
     }
 
@@ -613,10 +626,11 @@ const PortfolioManager = (function() {
             const tr = document.createElement('tr');
             tr.innerHTML = `
                 <td>${inv.ticker}</td>
+                <td>${inv.currency || ''}</td>
                 <td>${inv.name || ''}</td>
                 <td class="number-cell">${inv.quantity}</td>
-                <td class="number-cell">${formatCurrency(inv.purchasePrice)}</td>
-                <td class="number-cell">${formatCurrency(inv.lastPrice)}</td>
+                <td class="number-cell">${formatCurrency(inv.purchasePrice, inv.currency)}</td>
+                <td class="number-cell">${formatCurrency(inv.lastPrice, inv.currency)}</td>
                 <td>${inv.tradeDate}</td>`;
             historyBody.appendChild(tr);
         });
@@ -634,25 +648,26 @@ const PortfolioManager = (function() {
     function handleEditInput() {
         const qty = parseFloat(document.getElementById('edit-quantity').value) || 0;
         const price = parseFloat(document.getElementById('edit-last-price').value) || 0;
-        editTotal.textContent = formatCurrency(qty * price);
+        const currency = document.getElementById('edit-currency').value || 'USD';
+        editTotal.textContent = formatCurrency(qty * price, currency);
     }
 
     async function fetchLastPrices() {
         if (investments.length === 0) return;
 
         const priceMap = {};
+        const currencyMap = {};
         const tickers = Array.from(new Set(investments.map(inv => inv.ticker)));
 
         const fetches = tickers.map(ticker => {
-            const url = `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(ticker)}&token=${API_KEY}`;
-            return fetch(url)
-                .then(res => res.json())
-                .then(data => {
-                    if (data && typeof data.c === 'number') {
-                        priceMap[ticker] = parseFloat(data.c);
-                    }
-                })
-                .catch(() => {});
+            const inv = investments.find(i => i.ticker === ticker);
+            const curr = inv ? inv.currency || 'USD' : 'USD';
+            return fetchQuote(ticker, curr).then(res => {
+                if (res.price !== null) {
+                    priceMap[ticker] = res.price;
+                    currencyMap[ticker] = res.currency || curr;
+                }
+            }).catch(() => {});
         });
 
         await Promise.all(fetches);
@@ -660,6 +675,7 @@ const PortfolioManager = (function() {
         investments.forEach(inv => {
             if (priceMap[inv.ticker] !== undefined) {
                 inv.lastPrice = priceMap[inv.ticker];
+                inv.currency = currencyMap[inv.ticker] || inv.currency;
             }
         });
 
@@ -676,6 +692,7 @@ const PortfolioManager = (function() {
         const purchase = parseFloat(document.getElementById('edit-purchase-price').value) || 0;
         const date = document.getElementById('edit-purchase-date').value;
         const last = parseFloat(document.getElementById('edit-last-price').value) || 0;
+        const currency = document.getElementById('edit-currency').value || 'USD';
         if (qty <= 0 || purchase <= 0 || last <= 0) return;
         const today = new Date().toISOString().split('T')[0];
         if (!date || date > today) {
@@ -689,6 +706,7 @@ const PortfolioManager = (function() {
         inv.purchasePrice = purchase;
         inv.lastPrice = last;
         inv.tradeDate = date;
+        inv.currency = currency;
 
         saveData();
         renderTable();

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -352,6 +352,7 @@ const PortfolioManager = (function() {
                 map[inv.ticker] = {
                     ticker: inv.ticker,
                     name: inv.name,
+                    currency: inv.currency || 'USD',
                     quantity: 0,
                     cost: 0,
                     last: 0,
@@ -365,10 +366,14 @@ const PortfolioManager = (function() {
             item.cost += inv.purchasePrice * inv.quantity;
             item.last += inv.lastPrice;
             item.count += 1;
+            if (!item.currency && inv.currency) {
+                item.currency = inv.currency;
+            }
         });
         return Object.values(map).map(it => ({
             ticker: it.ticker,
             name: it.name,
+            currency: it.currency,
             quantity: it.quantity,
             purchasePrice: it.quantity ? it.cost / it.quantity : 0,
             lastPrice: it.count ? it.last / it.count : 0,

--- a/app/js/stockFinance.js
+++ b/app/js/stockFinance.js
@@ -240,7 +240,8 @@ const StockFinance = (function() {
                     });
 
                 currentTicker = ticker;
-                currentSharePrice = await PortfolioManager.fetchQuote(ticker);
+                const quote = await PortfolioManager.fetchQuote(ticker);
+                currentSharePrice = quote.price;
                 showZeroInfo();
                 renderTable();
             } else {


### PR DESCRIPTION
## Summary
- include currency when fetching quotes
- show currency field in add/edit investment forms
- display currency column in portfolio and history tables
- store currency per investment and update formatters
- update tests for new currency column and fetchQuote

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688568a965a0832fba7b8b5cc8e64cec