### PR TITLE
Add show in summary toggle for portfolios

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -205,6 +205,7 @@
         .summary-toggle input[type="checkbox"] {
             width: 24px;
             height: 24px;
+            accent-color: var(--primary-blue);
         }
 
         .menu-toggle {
@@ -999,5 +1000,6 @@
             .summary-toggle input[type="checkbox"] {
                 width: 20px;
                 height: 20px;
+                accent-color: var(--primary-blue);
             }
         }

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -199,7 +199,12 @@
             display: flex;
             align-items: center;
             gap: 0.25rem;
-            font-size: 0.9rem;
+            font-size: 1rem;
+        }
+
+        .summary-toggle input[type="checkbox"] {
+            width: 24px;
+            height: 24px;
         }
 
         .menu-toggle {
@@ -989,6 +994,10 @@
                 color: white;
             }
             .summary-toggle {
-                font-size: 0.8rem;
+                font-size: 0.9rem;
+            }
+            .summary-toggle input[type="checkbox"] {
+                width: 20px;
+                height: 20px;
             }
         }

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -195,6 +195,13 @@
             gap: 0.5rem;
         }
 
+        .summary-toggle {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            font-size: 0.9rem;
+        }
+
         .menu-toggle {
             display: none;
         }
@@ -980,5 +987,8 @@
                 display: inline-flex;
                 border: 1px solid var(--primary-blue-dark);
                 color: white;
+            }
+            .summary-toggle {
+                font-size: 0.8rem;
             }
         }

--- a/app/index.html
+++ b/app/index.html
@@ -58,6 +58,7 @@
                             <button class="btn btn-secondary" id="transaction-history-btn">Transaction History</button>
                             <button class="btn btn-secondary" id="add-portfolio-btn">Add Portfolio</button>
                             <button class="btn btn-secondary" id="remove-portfolio-btn">Remove Portfolio</button>
+                            <label class="summary-toggle"><input type="checkbox" id="summary-toggle" checked> Show in Summary</label>
                         </div>
                         <button class="icon-btn menu-toggle" id="portfolio-menu-toggle" aria-label="More actions" aria-expanded="false" aria-controls="portfolio-actions-menu">
                             <ion-icon name="ellipsis-vertical"></ion-icon>


### PR DESCRIPTION
## Summary
- allow portfolios to be hidden from the Summary tab
- add a checkbox in portfolio actions menu to toggle inclusion
- style the summary toggle control

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68857568f158832fb0c0b2ab1f894b35