### PR TITLE
Add Settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The Personal Finance Dashboard is designed as a single HTML file application tha
 - Export/import functionality for data portability
 - Data validation and migration for legacy formats
 - Storage usage monitoring with automatic cleanup
+- Configurable base currency stored locally
 
 ## Technology Stack
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -196,6 +196,12 @@ To start fresh:
 2. Click **"Clear All Data"**
 3. Confirm you want to delete everything
 
+### Changing Base Currency
+
+1. Open the **Settings** tab
+2. Choose your preferred currency (USD, GBP or EUR) from the **Base Currency** dropdown
+3. The selection is saved automatically and will be used across the application
+
 ## Tips for Best Results
 
 ### Portfolio Management Tips

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -54,3 +54,16 @@ test('investment forms allow selecting currency', () => {
   expect(addOptions).toEqual(expect.arrayContaining(['USD', 'GBP']));
   expect(editOptions).toEqual(expect.arrayContaining(['USD', 'GBP']));
 });
+
+test('settings tab contains base currency select', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const tab = doc.querySelector('button.nav-tab[data-tab="settings"]');
+  const select = doc.getElementById('base-currency-select');
+  expect(tab).not.toBeNull();
+  expect(select).not.toBeNull();
+  const options = Array.from(select.querySelectorAll('option')).map(o => o.value);
+  expect(options).toEqual(['USD', 'GBP', 'EUR']);
+});

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -16,6 +16,7 @@ test('FinancialDashboard global object exists with init and removeTicker', () =>
     'calculator.js',
     'stockTracker.js',
     'stockFinance.js',
+    'settings.js',
     'financialDashboard.js',
     'marketStatus.js'
   ].forEach(file => {
@@ -42,4 +43,19 @@ test('fetchQuote returns price and currency', async () => {
   vm.runInContext(content, context);
   const result = await vm.runInContext('PortfolioManager.fetchQuote("TEST")', context);
   expect(result).toEqual({ price: 123.45, currency: 'EUR' });
+});
+
+test('Settings module saves currency to localStorage', () => {
+  const html = '<!DOCTYPE html><html><body>' +
+    '<select id="base-currency-select">' +
+    '<option value="USD">USD</option><option value="GBP">GBP</option><option value="EUR">EUR</option>' +
+    '</select></body></html>';
+  const dom = new JSDOM(html, {url: 'http://localhost'});
+  const { window } = dom;
+  const context = vm.createContext(window);
+  const content = fs.readFileSync(path.resolve(__dirname, '../app/js/settings.js'), 'utf8');
+  vm.runInContext(content, context);
+  vm.runInContext('Settings.init()', context);
+  vm.runInContext('document.getElementById("base-currency-select").value = "GBP"; document.getElementById("base-currency-select").dispatchEvent(new window.Event("change"));', context);
+  expect(window.localStorage.getItem('pf_base_currency')).toBe('GBP');
 });

--- a/app/index.html
+++ b/app/index.html
@@ -43,6 +43,7 @@
         <button class="nav-tab" data-tab="calculators">Calculators</button>
         <button class="nav-tab" data-tab="stock-tracker">Stock Performance Tracker</button>
         <button class="nav-tab" data-tab="stock-finance">Stock Finance Performance</button>
+        <button class="nav-tab" data-tab="settings">Settings</button>
     </nav>
 
     <div class="container">
@@ -630,6 +631,20 @@
                     </table>
                 </div>
             </div>
+            <!-- Settings Tab -->
+            <div id="settings" class="tab-content">
+                <div class="section-header">
+                    <h2 class="section-title">Settings</h2>
+                </div>
+                <div class="form-group">
+                    <label for="base-currency-select">Base Currency</label>
+                    <select id="base-currency-select">
+                        <option value="USD">USD</option>
+                        <option value="GBP">GBP</option>
+                        <option value="EUR">EUR</option>
+                    </select>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -657,6 +672,7 @@
     <script src="js/calculator.js"></script>
     <script src="js/stockTracker.js"></script>
     <script src="js/stockFinance.js"></script>
+    <script src="js/settings.js"></script>
     <script src="js/financialDashboard.js"></script>
     <script src="js/marketStatus.js"></script>
     <script src="js/priceUpdater.js"></script>

--- a/app/js/financialDashboard.js
+++ b/app/js/financialDashboard.js
@@ -3,6 +3,7 @@ const FinancialDashboard = (function() {
 
     function init() {
         TabManager.init();
+        Settings.init();
         PortfolioManager.init();
         Calculator.init();
         StockTracker.init();

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -1,0 +1,32 @@
+const Settings = (function() {
+    'use strict';
+
+    const STORAGE_KEY = 'pf_base_currency';
+
+    function load() {
+        return localStorage.getItem(STORAGE_KEY) || 'USD';
+    }
+
+    function save(value) {
+        localStorage.setItem(STORAGE_KEY, value);
+    }
+
+    function getBaseCurrency() {
+        return load();
+    }
+
+    function setBaseCurrency(value) {
+        save(value);
+    }
+
+    function init() {
+        const select = document.getElementById('base-currency-select');
+        if (!select) return;
+        select.value = load();
+        select.addEventListener('change', () => {
+            save(select.value);
+        });
+    }
+
+    return { init, getBaseCurrency, setBaseCurrency };
+})();


### PR DESCRIPTION
## Summary
- create Settings module to manage base currency
- initialize Settings in FinancialDashboard
- add Settings tab and base currency dropdown to index
- document base currency feature in README and USER_GUIDE
- test settings UI and persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885fcb7fab0832f94f4f84385231191