### PR TITLE
Add AGENT rule for pop-up input focus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Rules
+
+* When implementing or updating pop-up dialogues that ask the user for text input, automatically set focus to the text input field so the user can begin typing immediately without extra clicks.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with an instruction for pop-up dialogues to automatically focus text inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68861dd55c48832f94a18cd729f55f9a