### PR TITLE
Populate base currency from forex data

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -65,5 +65,5 @@ test('settings tab contains base currency select', () => {
   expect(tab).not.toBeNull();
   expect(select).not.toBeNull();
   const options = Array.from(select.querySelectorAll('option')).map(o => o.value);
-  expect(options).toEqual(['USD', 'GBP', 'EUR']);
+  expect(options.length).toBe(0);
 });

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -48,9 +48,8 @@ test('fetchQuote returns price and currency', async () => {
 
 test('Settings module saves currency to localStorage', () => {
   const html = '<!DOCTYPE html><html><body>' +
-    '<select id="base-currency-select">' +
-    '<option value="USD">USD</option><option value="GBP">GBP</option><option value="EUR">EUR</option>' +
-    '</select></body></html>';
+    '<select id="base-currency-select"></select>' +
+    '</body></html>';
   const dom = new JSDOM(html, {url: 'http://localhost'});
   const { window } = dom;
   const context = vm.createContext(window);

--- a/app/index.html
+++ b/app/index.html
@@ -638,11 +638,7 @@
                 </div>
                 <div class="form-group">
                     <label for="base-currency-select">Base Currency</label>
-                    <select id="base-currency-select">
-                        <option value="USD">USD</option>
-                        <option value="GBP">GBP</option>
-                        <option value="EUR">EUR</option>
-                    </select>
+                    <select id="base-currency-select"></select>
                 </div>
             </div>
         </div>

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -19,13 +19,36 @@ const Settings = (function() {
         save(value);
     }
 
+    function populateOptions(data) {
+        const select = document.getElementById('base-currency-select');
+        if (!select) return;
+        const stored = load();
+        let codes = ['USD', 'GBP', 'EUR'];
+        if (data && data.conversion_rates) {
+            codes = Object.keys(data.conversion_rates);
+        }
+        select.innerHTML = '';
+        codes.forEach(code => {
+            const opt = document.createElement('option');
+            opt.value = code;
+            opt.textContent = code;
+            select.appendChild(opt);
+        });
+        select.value = stored;
+    }
+
     function init() {
         const select = document.getElementById('base-currency-select');
         if (!select) return;
-        select.value = load();
         select.addEventListener('change', () => {
             save(select.value);
         });
+
+        if (typeof ForexData !== 'undefined' && ForexData.getRates) {
+            ForexData.getRates().then(populateOptions).catch(() => populateOptions());
+        } else {
+            populateOptions();
+        }
     }
 
     return { init, getBaseCurrency, setBaseCurrency };


### PR DESCRIPTION
## Summary
- make base currency select empty and populate via JavaScript
- read forex data when Settings module initializes
- update HTML/JS tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68861d789e40832f88f477c08e308692