### PR TITLE
Show totals only in base currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Personal Finance Dashboard is designed as a single HTML file application tha
 - Real-time profit/loss calculations with percentage gains/losses
 - Interactive charts showing portfolio allocation and performance
 - Investment summary with total values, returns, and transaction history
-- Optional totals row converts foreign currency holdings to your chosen base currency
+- Portfolio totals automatically convert all holdings to your chosen base currency
 - Drag-and-drop reordering of portfolio positions
 
 ### 🧮 Financial Calculators

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -57,7 +57,7 @@ The top section shows:
 - **Total Portfolio Value**: Current worth of all investments
 - **Total Gain/Loss**: How much you've made or lost
 - **Gain/Loss Percentage**: Your overall return percentage
-- When positions use different currencies, a second totals line shows the converted values in your base currency
+- All totals are displayed in your selected base currency
 
 #### Portfolio Chart
 The pie chart shows:

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -68,13 +68,13 @@ test('settings tab contains base currency select', () => {
   expect(options.length).toBe(0);
 });
 
-test('portfolio table includes base totals row', () => {
+test('portfolio table shows totals row', () => {
   const htmlPath = path.resolve(__dirname, '../app/index.html');
   const html = fs.readFileSync(htmlPath, 'utf8');
   const dom = new JSDOM(html);
   const doc = dom.window.document;
-  const row = doc.getElementById('portfolio-base-total-row');
-  const value = doc.getElementById('portfolio-base-total-value');
+  const row = doc.getElementById('portfolio-total-row');
+  const value = doc.getElementById('portfolio-total-value');
   expect(row).not.toBeNull();
   expect(value).not.toBeNull();
 });

--- a/app/index.html
+++ b/app/index.html
@@ -86,20 +86,12 @@
                         </thead>
                         <tbody id="portfolio-body"></tbody>
                         <tfoot>
-                            <tr class="summary-row">
+                            <tr class="summary-row" id="portfolio-total-row">
                                 <td></td>
-                                <td colspan="6">Total</td>
+                                <td colspan="6">Total (<span id="portfolio-base-currency-label">USD</span>)</td>
                                 <td id="portfolio-total-value" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-pl" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-plpct" class="number-cell">0.00%</td>
-                                <td></td>
-                            </tr>
-                            <tr class="summary-row" id="portfolio-base-total-row" style="display:none;">
-                                <td></td>
-                                <td colspan="6">Total (<span id="portfolio-base-currency-label">USD</span>)</td>
-                                <td id="portfolio-base-total-value" class="number-cell">$0.00</td>
-                                <td id="portfolio-base-total-pl" class="number-cell">$0.00</td>
-                                <td id="portfolio-base-total-plpct" class="number-cell">0.00%</td>
                                 <td></td>
                             </tr>
                         </tfoot>

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -190,45 +190,25 @@ const PortfolioManager = (function() {
     }
 
     async function updateTotals() {
-        let totalValue = 0;
-        let totalCost = 0;
         let totalValueBase = 0;
         let totalCostBase = 0;
         const baseCurrency = Settings.getBaseCurrency ? Settings.getBaseCurrency() : 'USD';
         const data = aggregateInvestments();
         const ratesData = await ForexData.getRates();
         const rates = ratesData && ratesData.conversion_rates ? ratesData.conversion_rates : null;
-        let hasForeign = false;
         data.forEach(inv => {
             const value = inv.quantity * inv.lastPrice;
             const cost = inv.quantity * inv.purchasePrice;
-            totalValue += value;
-            totalCost += cost;
             totalValueBase += convertCurrency(value, inv.currency, baseCurrency, rates);
             totalCostBase += convertCurrency(cost, inv.currency, baseCurrency, rates);
-            if (inv.currency !== baseCurrency) hasForeign = true;
         });
-        const totalPL = totalValue - totalCost;
-        const totalPLPct = totalCost ? (totalPL / totalCost) * 100 : 0;
+        const basePL = totalValueBase - totalCostBase;
+        const basePLPct = totalCostBase ? (basePL / totalCostBase) * 100 : 0;
 
-        document.getElementById('portfolio-total-value').textContent = formatCurrency(totalValue, baseCurrency);
-        document.getElementById('portfolio-total-pl').textContent = formatCurrency(totalPL, baseCurrency);
-        document.getElementById('portfolio-total-plpct').textContent = totalPLPct.toFixed(2) + '%';
-
-        const baseRow = document.getElementById('portfolio-base-total-row');
-        if (baseRow) {
-            if (hasForeign) {
-                const basePL = totalValueBase - totalCostBase;
-                const basePLPct = totalCostBase ? (basePL / totalCostBase) * 100 : 0;
-                document.getElementById('portfolio-base-currency-label').textContent = baseCurrency;
-                document.getElementById('portfolio-base-total-value').textContent = formatCurrency(totalValueBase, baseCurrency);
-                document.getElementById('portfolio-base-total-pl').textContent = formatCurrency(basePL, baseCurrency);
-                document.getElementById('portfolio-base-total-plpct').textContent = basePLPct.toFixed(2) + '%';
-                baseRow.style.display = '';
-            } else {
-                baseRow.style.display = 'none';
-            }
-        }
+        document.getElementById('portfolio-base-currency-label').textContent = baseCurrency;
+        document.getElementById('portfolio-total-value').textContent = formatCurrency(totalValueBase, baseCurrency);
+        document.getElementById('portfolio-total-pl').textContent = formatCurrency(basePL, baseCurrency);
+        document.getElementById('portfolio-total-plpct').textContent = basePLPct.toFixed(2) + '%';
     }
 
     function generateColor(idx) {


### PR DESCRIPTION
## Summary
- keep only a single totals row in the portfolio table
- convert totals to the selected base currency when computing them
- update docs and tests to reference the revised totals row

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864eb978a8832f9c7afa1af3411ab8