### PR TITLE
Add daily exchange rate note in settings

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -202,6 +202,7 @@ To start fresh:
 1. Open the **Settings** tab
 2. Choose your preferred currency (USD, GBP or EUR) from the **Base Currency** dropdown
 3. The selection is saved automatically and will be used across the application
+4. Exchange rates refresh once a day so your totals stay accurate
 
 ## Tips for Best Results
 

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -250,6 +250,12 @@
             box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
         }
 
+        .form-hint {
+            margin-top: 0.5rem;
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+        }
+
         .btn {
             padding: 0.75rem 1.5rem;
             border: none;

--- a/app/index.html
+++ b/app/index.html
@@ -639,6 +639,7 @@
                 <div class="form-group">
                     <label for="base-currency-select">Base Currency</label>
                     <select id="base-currency-select"></select>
+                    <p class="form-hint">Exchange rates refresh once a day to keep totals accurate.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- mention daily refresh of exchange rates in settings
- style hint text
- document the daily refresh in the user guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688650c0feb0832f90a0a7327d28a2bc