### PR TITLE
Enable edit/delete for pension entries

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -261,6 +261,7 @@
                                 <th>YTD %</th>
                                 <th>Total P&amp;L</th>
                                 <th>Total %</th>
+                                <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody id="pension-body"></tbody>
@@ -315,6 +316,31 @@
                             <div class="modal-actions">
                                 <button type="button" class="btn btn-secondary" id="cancel-pension-entry">Cancel</button>
                                 <button type="submit" class="btn btn-primary">Add</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <!-- Edit Pension Entry Modal -->
+                <div id="pension-edit-modal" class="modal">
+                    <div class="modal-content">
+                        <h3>Edit Entry</h3>
+                        <form id="pension-edit-form">
+                            <div class="form-group">
+                                <label for="pension-edit-date">Date</label>
+                                <input type="date" id="pension-edit-date" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="pension-edit-value">Current Value</label>
+                                <input type="number" step="0.01" id="pension-edit-value" required>
+                            </div>
+                            <div class="form-group" id="edit-payment-group">
+                                <label for="pension-edit-payment">Payment</label>
+                                <input type="number" step="0.01" id="pension-edit-payment">
+                            </div>
+                            <div class="modal-actions">
+                                <button type="button" class="btn btn-secondary" id="cancel-pension-edit">Cancel</button>
+                                <button type="submit" class="btn btn-primary">Save</button>
                             </div>
                         </form>
                     </div>

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -25,6 +25,14 @@ const PensionManager = (function() {
     const entryValueInput = document.getElementById('pension-entry-value');
     const entryPaymentInput = document.getElementById('pension-entry-payment');
     const entryCancel = document.getElementById('cancel-pension-entry');
+
+    const editEntryModal = document.getElementById('pension-edit-modal');
+    const editEntryForm = document.getElementById('pension-edit-form');
+    const editDateInput = document.getElementById('pension-edit-date');
+    const editValueInput = document.getElementById('pension-edit-value');
+    const editPaymentInput = document.getElementById('pension-edit-payment');
+    const editCancel = document.getElementById('cancel-pension-edit');
+    let editIndex = null;
     const paymentHeader = document.querySelector('#pension-table .payment-col');
 
     function getStorageKey(id) {
@@ -160,6 +168,58 @@ const PensionManager = (function() {
         closeEntryModal();
     }
 
+    function openEditEntryModal(idx) {
+        editIndex = idx;
+        const entry = entries[idx];
+        if (!entry) return;
+        editDateInput.value = entry.date;
+        editValueInput.value = entry.value;
+        editPaymentInput.value = entry.payment || '';
+        const current = pensions.find(p => p.id === currentPensionId);
+        if (current && current.type === 'growth') {
+            editPaymentInput.parentElement.style.display = 'none';
+        } else {
+            editPaymentInput.parentElement.style.display = 'block';
+        }
+        editEntryModal.style.display = 'flex';
+        editDateInput.focus();
+    }
+
+    function closeEditEntryModal() {
+        editEntryModal.style.display = 'none';
+        editIndex = null;
+    }
+
+    function saveEditEntry(e) {
+        e.preventDefault();
+        if (editIndex === null) return;
+        const date = editDateInput.value;
+        const value = parseFloat(editValueInput.value);
+        const payment = parseFloat(editPaymentInput.value) || 0;
+        if (!date || isNaN(value)) return;
+        entries[editIndex] = { date, value, payment };
+        entries.sort((a,b)=>new Date(a.date)-new Date(b.date));
+        saveEntries();
+        renderTable();
+        closeEditEntryModal();
+    }
+
+    async function handleRowAction(e) {
+        const btn = e.target.closest('button');
+        if (!btn) return;
+        const idx = parseInt(btn.dataset.index, 10);
+        if (btn.classList.contains('edit-btn')) {
+            openEditEntryModal(idx);
+        } else if (btn.classList.contains('delete-btn')) {
+            const confirmed = await DialogManager.confirm('Delete this entry?', 'Delete');
+            if (confirmed) {
+                entries.splice(idx, 1);
+                saveEntries();
+                renderTable();
+            }
+        }
+    }
+
     function formatCurrency(val) {
         return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(val);
     }
@@ -174,7 +234,7 @@ const PensionManager = (function() {
         let ytdPayments = 0;
         let totalPayments = 0;
         let currentYear = entries[0] ? new Date(entries[0].date).getFullYear() : new Date().getFullYear();
-        return entries.map(entry => {
+        return entries.map((entry, idx) => {
             const year = new Date(entry.date).getFullYear();
             if (year !== currentYear) {
                 currentYear = year;
@@ -194,7 +254,8 @@ const PensionManager = (function() {
             return Object.assign({}, entry, {
                 monthlyPL, monthlyPLPct,
                 ytdPL, ytdPLPct,
-                totalPL, totalPLPct
+                totalPL, totalPLPct,
+                index: idx
             });
         });
     }
@@ -206,6 +267,7 @@ const PensionManager = (function() {
         const stats = computeStats();
         stats.forEach(st => {
             const row = document.createElement('tr');
+            row.dataset.index = st.index;
             row.innerHTML = `
                 <td>${st.date}</td>
                 ${pensions.find(p=>p.id===currentPensionId).type==='payments'?`<td class="number-cell">${formatCurrency(st.payment)}</td>`:''}
@@ -216,6 +278,14 @@ const PensionManager = (function() {
                 <td class="number-cell">${st.ytdPLPct.toFixed(2)}%</td>
                 <td class="number-cell">${formatCurrency(st.totalPL)}</td>
                 <td class="number-cell">${st.totalPLPct.toFixed(2)}%</td>
+                <td class="actions-cell">
+                    <button class="icon-btn edit-btn" data-index="${st.index}" title="Edit">
+                        <svg width="16" height="16" viewBox="0 0 512 512"><polygon points="364.13 125.25 87 403 64 448 108.99 425 386.75 147.87 364.13 125.25" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><path d="M420.69,68.69,398.07,91.31l22.62,22.63,22.62-22.63a16,16,0,0,0,0-22.62h0A16,16,0,0,0,420.69,68.69Z" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
+                    </button>
+                    <button class="icon-btn delete-btn" data-index="${st.index}" title="Delete">
+                        <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
+                    </button>
+                </td>
             `;
             tbody.appendChild(row);
         });
@@ -242,6 +312,11 @@ const PensionManager = (function() {
         addEntryBtn.addEventListener('click', openEntryModal);
         entryCancel.addEventListener('click', closeEntryModal);
         entryForm.addEventListener('submit', addEntry);
+
+        document.getElementById('pension-body').addEventListener('click', handleRowAction);
+        editCancel.addEventListener('click', closeEditEntryModal);
+        editEntryForm.addEventListener('submit', saveEditEntry);
+        editEntryModal.addEventListener('click', e => { if (e.target === editEntryModal) closeEditEntryModal(); });
 
         newPensionModal.addEventListener('click', e => { if (e.target === newPensionModal) closeNewPensionModal(); });
         entryModal.addEventListener('click', e => { if (e.target === entryModal) closeEntryModal(); });


### PR DESCRIPTION
## Summary
- add Actions column to pension table and modal to edit entries
- allow editing and deleting pension entries in pension manager

## Testing
- `npm install` in `app/js`
- `npm test` in `app/js`


------
https://chatgpt.com/codex/tasks/task_e_688683055720832fa6e7a65c167a441d