### PR TITLE
Implement dd/mm/yyyy date format

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -241,7 +241,7 @@ To start fresh:
 #### Calculations Seem Wrong
 - Verify all input values are correct
 - Check that percentages are entered as numbers (7, not 0.07)
-- Ensure dates are in correct format
+ - Ensure dates are in **dd/mm/yyyy** format
 
 #### Performance Issues
 - Clear old data you no longer need

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -10,6 +10,7 @@ test('FinancialDashboard global object exists with init and removeTicker', () =>
   const context = vm.createContext(dom.window);
   [
     'dialogManager.js',
+    'dateUtils.js',
     'tabManager.js',
     'portfolioStorage.js',
     'portfolioManager.js',
@@ -59,4 +60,12 @@ test('Settings module saves currency to localStorage', () => {
   vm.runInContext('Settings.init()', context);
   vm.runInContext('document.getElementById("base-currency-select").value = "GBP"; document.getElementById("base-currency-select").dispatchEvent(new window.Event("change"));', context);
   expect(window.localStorage.getItem('pf_base_currency')).toBe('GBP');
+});
+
+test('DateUtils.formatDate formats date correctly', () => {
+  const context = vm.createContext({});
+  const content = fs.readFileSync(path.resolve(__dirname, '../app/js/dateUtils.js'), 'utf8');
+  vm.runInContext(content, context);
+  const result = vm.runInContext('DateUtils.formatDate("2024-05-01")', context);
+  expect(result).toBe('01/05/2024');
 });

--- a/app/index.html
+++ b/app/index.html
@@ -765,6 +765,7 @@
     <div id="tooltip" class="tooltip"></div>
 
     <script src="js/dialogManager.js"></script>
+    <script src="js/dateUtils.js"></script>
     <script src="js/tabManager.js"></script>
     <script src="js/portfolioStorage.js"></script>
     <script src="js/portfolioManager.js"></script>

--- a/app/js/dateUtils.js
+++ b/app/js/dateUtils.js
@@ -1,0 +1,10 @@
+const DateUtils = (function() {
+    'use strict';
+    function formatDate(dateStr) {
+        if (!dateStr) return '';
+        const [y, m, d] = dateStr.split('-');
+        if (!y || !m || !d) return dateStr;
+        return `${d}/${m}/${y}`;
+    }
+    return { formatDate };
+})();

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -269,7 +269,7 @@ const PensionManager = (function() {
             const row = document.createElement('tr');
             row.dataset.index = st.index;
             row.innerHTML = `
-                <td>${st.date}</td>
+                <td>${DateUtils.formatDate(st.date)}</td>
                 ${pensions.find(p=>p.id===currentPensionId).type==='payments'?`<td class="number-cell">${formatCurrency(st.payment)}</td>`:''}
                 <td class="number-cell">${formatCurrency(st.value)}</td>
                 <td class="number-cell">${formatCurrency(st.monthlyPL)}</td>

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -630,7 +630,7 @@ const PortfolioManager = (function() {
                 const inv = investments[i];
                 const opt = document.createElement('option');
                 opt.value = i;
-                opt.textContent = `${inv.quantity} @ ${formatCurrency(inv.purchasePrice, inv.currency)} on ${inv.tradeDate}`;
+                opt.textContent = `${inv.quantity} @ ${formatCurrency(inv.purchasePrice, inv.currency)} on ${DateUtils.formatDate(inv.tradeDate)}`;
                 editRecordSelect.appendChild(opt);
             });
             editRecordGroup.style.display = 'block';
@@ -672,7 +672,7 @@ const PortfolioManager = (function() {
                 <td class="number-cell">${inv.quantity}</td>
                 <td class="number-cell">${formatCurrency(inv.purchasePrice, inv.currency)}</td>
                 <td class="number-cell">${formatCurrency(inv.lastPrice, inv.currency)}</td>
-                <td>${inv.tradeDate}</td>`;
+                <td>${DateUtils.formatDate(inv.tradeDate)}</td>`;
             historyBody.appendChild(tr);
         });
     }


### PR DESCRIPTION
## Summary
- add `DateUtils` module for common date formatting
- show dd/mm/yyyy dates in portfolio history and pensions
- load `dateUtils.js` in the HTML
- document the required date format in the user guide
- test new formatting helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68868527003c832f900d83636acc9cc7