### PR TITLE
Display pension values in base currency

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -89,3 +89,12 @@ test('pension tab contains entry table', () => {
   expect(table).not.toBeNull();
   expect(nameInput).not.toBeNull();
 });
+
+test('pension header shows base currency label', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const label = doc.getElementById('pension-base-currency-label');
+  expect(label).not.toBeNull();
+});

--- a/app/index.html
+++ b/app/index.html
@@ -252,7 +252,7 @@
                             <tr>
                                 <th>Date</th>
                                 <th class="payment-col" style="display:none;">Payment</th>
-                                <th>Current Value</th>
+                                <th>Current Value (<span id="pension-base-currency-label">USD</span>)</th>
                                 <th>Monthly P&amp;L</th>
                                 <th>Monthly %</th>
                                 <th>YTD P&amp;L</th>

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -25,6 +25,7 @@ const PensionManager = (function() {
     const entryValueInput = document.getElementById('pension-entry-value');
     const entryPaymentInput = document.getElementById('pension-entry-payment');
     const entryCancel = document.getElementById('cancel-pension-entry');
+    const baseCurrencyLabel = document.getElementById('pension-base-currency-label');
 
     const editEntryModal = document.getElementById('pension-edit-modal');
     const editEntryForm = document.getElementById('pension-edit-form');
@@ -220,8 +221,17 @@ const PensionManager = (function() {
         }
     }
 
-    function formatCurrency(val) {
-        return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(val);
+    function formatCurrency(val, currency = 'USD') {
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(val);
+    }
+
+    function convertCurrency(value, from, to, rates) {
+        if (!rates || from === to) return value;
+        const fromRate = rates[from];
+        const toRate = rates[to];
+        if (!fromRate || !toRate) return value;
+        const usdValue = value / fromRate;
+        return usdValue * toRate;
     }
 
     function computeStats() {
@@ -260,11 +270,15 @@ const PensionManager = (function() {
         });
     }
 
-    function renderTable() {
+    async function renderTable() {
         const tbody = document.getElementById('pension-body');
         if (!tbody) return;
         tbody.innerHTML = '';
         const stats = computeStats();
+        const baseCurrency = Settings.getBaseCurrency ? Settings.getBaseCurrency() : 'USD';
+        const ratesData = await ForexData.getRates();
+        const rates = ratesData && ratesData.conversion_rates ? ratesData.conversion_rates : null;
+        if (baseCurrencyLabel) baseCurrencyLabel.textContent = baseCurrency;
         stats.forEach(st => {
             const row = document.createElement('tr');
             row.dataset.index = st.index;
@@ -277,15 +291,21 @@ const PensionManager = (function() {
             const ytdPctClass = st.ytdPLPct > 0 ? 'growth-positive' : st.ytdPLPct < 0 ? 'growth-negative' : '';
             const totalPctClass = st.totalPLPct > 0 ? 'growth-positive' : st.totalPLPct < 0 ? 'growth-negative' : '';
 
+            const paymentVal = convertCurrency(st.payment || 0, 'USD', baseCurrency, rates);
+            const valueVal = convertCurrency(st.value, 'USD', baseCurrency, rates);
+            const monthlyVal = convertCurrency(st.monthlyPL, 'USD', baseCurrency, rates);
+            const ytdVal = convertCurrency(st.ytdPL, 'USD', baseCurrency, rates);
+            const totalVal = convertCurrency(st.totalPL, 'USD', baseCurrency, rates);
+
             row.innerHTML = `
                 <td>${DateUtils.formatDate(st.date)}</td>
-                ${pensions.find(p=>p.id===currentPensionId).type==='payments'?`<td class="number-cell">${formatCurrency(st.payment)}</td>`:''}
-                <td class="number-cell">${formatCurrency(st.value)}</td>
-                <td class="number-cell ${monthlyClass}">${formatCurrency(st.monthlyPL)}</td>
+                ${pensions.find(p=>p.id===currentPensionId).type==='payments'?`<td class="number-cell">${formatCurrency(paymentVal, baseCurrency)}</td>`:''}
+                <td class="number-cell">${formatCurrency(valueVal, baseCurrency)}</td>
+                <td class="number-cell ${monthlyClass}">${formatCurrency(monthlyVal, baseCurrency)}</td>
                 <td class="number-cell ${monthlyPctClass}">${st.monthlyPLPct.toFixed(2)}%</td>
-                <td class="number-cell ${ytdClass}">${formatCurrency(st.ytdPL)}</td>
+                <td class="number-cell ${ytdClass}">${formatCurrency(ytdVal, baseCurrency)}</td>
                 <td class="number-cell ${ytdPctClass}">${st.ytdPLPct.toFixed(2)}%</td>
-                <td class="number-cell ${totalClass}">${formatCurrency(st.totalPL)}</td>
+                <td class="number-cell ${totalClass}">${formatCurrency(totalVal, baseCurrency)}</td>
                 <td class="number-cell ${totalPctClass}">${st.totalPLPct.toFixed(2)}%</td>
                 <td class="actions-cell">
                     <button class="icon-btn edit-btn" data-index="${st.index}" title="Edit">


### PR DESCRIPTION
## Summary
- add base currency label to pension table header
- convert pension stats to base currency using ForexData
- test for base currency label in pension table

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68869ffe5050832f80f61952b5a04a79