### PR TITLE
Add pension import/export

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -739,6 +739,11 @@
             border-bottom: 1px solid var(--border-color);
         }
 
+        /* Extra spacing when a section subtitle follows a form group */
+        .form-group + .section-subtitle {
+            margin-top: 1.5rem;
+        }
+
         /* Enhanced Calculator Section */
         .calculator-section {
             margin-bottom: 0;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -201,6 +201,11 @@
             gap: 0.5rem;
         }
 
+        .button-row {
+            display: flex;
+            gap: 0.5rem;
+        }
+
         .summary-toggle {
             display: flex;
             align-items: center;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -250,7 +250,23 @@
             transition: border-color 0.3s ease;
         }
 
+        .form-group textarea {
+            padding: 0.75rem;
+            border: 2px solid var(--border-color);
+            border-radius: 8px;
+            font-size: 1rem;
+            transition: border-color 0.3s ease;
+            width: 100%;
+            resize: vertical;
+        }
+
         .form-group input:focus, .form-group select:focus {
+            outline: none;
+            border-color: var(--primary-blue);
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+        }
+
+        .form-group textarea:focus {
             outline: none;
             border-color: var(--primary-blue);
             box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
@@ -846,6 +862,12 @@
 
         #dialog-modal .modal-content {
             width: 400px;
+            height: auto;
+        }
+
+        #export-pensions-modal .modal-content,
+        #import-pensions-modal .modal-content {
+            width: 500px;
             height: auto;
         }
 

--- a/app/index.html
+++ b/app/index.html
@@ -744,6 +744,7 @@
                     <select id="base-currency-select"></select>
                     <p class="form-hint">Exchange rates refresh once a day to keep totals accurate.</p>
                 </div>
+                <h3 class="section-subtitle">Pension</h3>
                 <div class="form-group">
                     <div class="button-row">
                         <button type="button" class="btn btn-secondary" id="export-pensions-btn">Export Pensions</button>

--- a/app/index.html
+++ b/app/index.html
@@ -745,8 +745,10 @@
                     <p class="form-hint">Exchange rates refresh once a day to keep totals accurate.</p>
                 </div>
                 <div class="form-group">
-                    <button type="button" class="btn btn-secondary" id="export-pensions-btn">Export Pensions</button>
-                    <button type="button" class="btn btn-secondary" id="import-pensions-btn">Import Pensions</button>
+                    <div class="button-row">
+                        <button type="button" class="btn btn-secondary" id="export-pensions-btn">Export Pensions</button>
+                        <button type="button" class="btn btn-secondary" id="import-pensions-btn">Import Pensions</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -783,8 +785,8 @@
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="import-pensions-text">Data</label>
-                    <textarea id="import-pensions-text" rows="6" required></textarea>
+                    <label for="import-pensions-file">File</label>
+                    <input type="file" id="import-pensions-file" accept=".json,.csv" required>
                 </div>
                 <div class="modal-actions">
                     <button type="button" class="btn btn-secondary" id="cancel-import-pensions">Cancel</button>

--- a/app/index.html
+++ b/app/index.html
@@ -744,7 +744,53 @@
                     <select id="base-currency-select"></select>
                     <p class="form-hint">Exchange rates refresh once a day to keep totals accurate.</p>
                 </div>
+                <div class="form-group">
+                    <button type="button" class="btn btn-secondary" id="export-pensions-btn">Export Pensions</button>
+                    <button type="button" class="btn btn-secondary" id="import-pensions-btn">Import Pensions</button>
+                </div>
             </div>
+        </div>
+    </div>
+
+    <!-- Export Pensions Modal -->
+    <div id="export-pensions-modal" class="modal">
+        <div class="modal-content">
+            <h3>Export Pensions</h3>
+            <div class="form-group">
+                <label for="export-pensions-format">Format</label>
+                <select id="export-pensions-format">
+                    <option value="json">JSON</option>
+                    <option value="csv">CSV</option>
+                </select>
+            </div>
+            <div class="modal-actions">
+                <button type="button" class="btn btn-secondary" id="cancel-export-pensions">Cancel</button>
+                <button type="button" class="btn btn-primary" id="download-export-pensions">Export</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Import Pensions Modal -->
+    <div id="import-pensions-modal" class="modal">
+        <div class="modal-content">
+            <h3>Import Pensions</h3>
+            <form id="import-pensions-form">
+                <div class="form-group">
+                    <label for="import-pensions-format">Format</label>
+                    <select id="import-pensions-format">
+                        <option value="json">JSON</option>
+                        <option value="csv">CSV</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="import-pensions-text">Data</label>
+                    <textarea id="import-pensions-text" rows="6" required></textarea>
+                </div>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn-secondary" id="cancel-import-pensions">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Import</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -44,6 +44,68 @@ const Settings = (function() {
             save(select.value);
         });
 
+        const exportBtn = document.getElementById('export-pensions-btn');
+        const importBtn = document.getElementById('import-pensions-btn');
+        const exportModal = document.getElementById('export-pensions-modal');
+        const exportFormat = document.getElementById('export-pensions-format');
+        const exportCancel = document.getElementById('cancel-export-pensions');
+        const exportDownload = document.getElementById('download-export-pensions');
+        const importModal = document.getElementById('import-pensions-modal');
+        const importForm = document.getElementById('import-pensions-form');
+        const importFormat = document.getElementById('import-pensions-format');
+        const importText = document.getElementById('import-pensions-text');
+        const importCancel = document.getElementById('cancel-import-pensions');
+
+        function openExport() {
+            exportFormat.value = 'json';
+            exportModal.style.display = 'flex';
+        }
+
+        function closeExport() {
+            exportModal.style.display = 'none';
+        }
+
+        function downloadExport() {
+            const fmt = exportFormat.value;
+            const data = PensionManager.exportData(fmt);
+            const blob = new Blob([data], { type: fmt === 'json' ? 'application/json' : 'text/csv' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = 'pensions.' + (fmt === 'json' ? 'json' : 'csv');
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(a.href);
+            closeExport();
+        }
+
+        function openImport() {
+            importFormat.value = 'json';
+            importText.value = '';
+            importModal.style.display = 'flex';
+            importText.focus();
+        }
+
+        function closeImport() {
+            importModal.style.display = 'none';
+        }
+
+        function handleImport(e) {
+            e.preventDefault();
+            PensionManager.importData(importText.value, importFormat.value);
+            closeImport();
+        }
+
+        if (exportBtn) exportBtn.addEventListener('click', openExport);
+        if (exportCancel) exportCancel.addEventListener('click', closeExport);
+        if (exportDownload) exportDownload.addEventListener('click', downloadExport);
+        if (exportModal) exportModal.addEventListener('click', e => { if (e.target === exportModal) closeExport(); });
+
+        if (importBtn) importBtn.addEventListener('click', openImport);
+        if (importCancel) importCancel.addEventListener('click', closeImport);
+        if (importForm) importForm.addEventListener('submit', handleImport);
+        if (importModal) importModal.addEventListener('click', e => { if (e.target === importModal) closeImport(); });
+
         if (typeof ForexData !== 'undefined' && ForexData.getRates) {
             ForexData.getRates().then(populateOptions).catch(() => populateOptions());
         } else {

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -53,7 +53,7 @@ const Settings = (function() {
         const importModal = document.getElementById('import-pensions-modal');
         const importForm = document.getElementById('import-pensions-form');
         const importFormat = document.getElementById('import-pensions-format');
-        const importText = document.getElementById('import-pensions-text');
+        const importFile = document.getElementById('import-pensions-file');
         const importCancel = document.getElementById('cancel-import-pensions');
 
         function openExport() {
@@ -81,9 +81,8 @@ const Settings = (function() {
 
         function openImport() {
             importFormat.value = 'json';
-            importText.value = '';
+            if (importFile) importFile.value = '';
             importModal.style.display = 'flex';
-            importText.focus();
         }
 
         function closeImport() {
@@ -92,8 +91,14 @@ const Settings = (function() {
 
         function handleImport(e) {
             e.preventDefault();
-            PensionManager.importData(importText.value, importFormat.value);
-            closeImport();
+            const file = importFile.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = function() {
+                PensionManager.importData(reader.result, importFormat.value);
+                closeImport();
+            };
+            reader.readAsText(file);
         }
 
         if (exportBtn) exportBtn.addEventListener('click', openExport);

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -82,6 +82,7 @@ const Settings = (function() {
         function openImport() {
             importFormat.value = 'json';
             if (importFile) importFile.value = '';
+            if (importFile) importFile.focus();
             importModal.style.display = 'flex';
         }
 


### PR DESCRIPTION
## Summary
- add pension import/export controls on settings page
- style textarea form field and pension modals
- implement pension export/import handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886abc9b128832f9f7d678cc4fcdb7a