### PR TITLE
Add pension analysis summary

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -269,6 +269,28 @@
                         <tbody id="pension-body"></tbody>
                     </table>
                 </div>
+                <div class="summary-cards" id="pension-summary-cards" style="display:none;">
+                    <div class="summary-card">
+                        <h4>Current CAGR</h4>
+                        <p id="pension-current-cagr"></p>
+                    </div>
+                    <div class="summary-card">
+                        <h4>Best Month</h4>
+                        <p id="pension-best-month"></p>
+                    </div>
+                    <div class="summary-card">
+                        <h4>Worst Month</h4>
+                        <p id="pension-worst-month"></p>
+                    </div>
+                    <div class="summary-card">
+                        <h4>Best Year</h4>
+                        <p id="pension-best-year"></p>
+                    </div>
+                    <div class="summary-card">
+                        <h4>Worst Year</h4>
+                        <p id="pension-worst-year"></p>
+                    </div>
+                </div>
 
                 <!-- New Pension Modal -->
                 <div id="new-pension-modal" class="modal">


### PR DESCRIPTION
## Summary
- add pension analysis summary cards in the Pension tab
- compute CAGR, best/worst months and years in PensionManager
- display the calculated statistics below the pension table

## Testing
- `npm install` within `app/js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b91d54fc832fa88b5ab14c30ce06