### PR TITLE
Implement portfolio-wide price refresh

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -69,3 +69,45 @@ test('DateUtils.formatDate formats date correctly', () => {
   const result = vm.runInContext('DateUtils.formatDate("2024-05-01")', context);
   expect(result).toBe('01/05/2024');
 });
+
+test('fetchLastPrices updates multiple portfolios', async () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {url: 'http://localhost'});
+  const { window } = dom;
+  const ids = [
+    'add-investment-btn','get-last-price-btn','add-portfolio-btn','remove-portfolio-btn','portfolio-tabs',
+    'investment-modal','investment-form','investment-ticker','investment-close','cancel-investment-btn','save-add-another-btn','investment-total-value',
+    'edit-investment-modal','edit-investment-form','edit-investment-close','edit-cancel-btn','edit-record-group','edit-record-select','edit-total-value',
+    'transaction-history-btn','transaction-history-modal','transaction-history-close','transaction-history-body','portfolio-menu-toggle','portfolio-actions-menu','summary-toggle',
+    'portfolio-body','portfolio-total-value','portfolio-total-pl','portfolio-total-plpct','portfolio-base-currency-label','investment-spread-chart','plpct-chart'
+  ];
+  ids.forEach(id => { const el = window.document.createElement(id.includes('chart') ? 'canvas' : 'div'); el.id = id; window.document.body.appendChild(el); });
+
+  const context = vm.createContext(window);
+  context.Chart = function() { this.data={labels:[],datasets:[{data:[]}]}; this.options={plugins:{tooltip:{callbacks:{}},title:{},legend:{}}}; this.update=() => {}; };
+  context.Settings = { getBaseCurrency: () => 'USD' };
+  context.ForexData = { getRates: () => Promise.resolve({ conversion_rates: { USD: 1 } }) };
+
+  window.fetch = jest.fn(url => {
+    if (url.includes('AAA')) {
+      return Promise.resolve({ json: () => Promise.resolve({ c: 111, currency: 'USD' }) });
+    }
+    return Promise.resolve({ json: () => Promise.resolve({ c: 222, currency: 'USD' }) });
+  });
+
+  window.localStorage.setItem('portfolioList', JSON.stringify([
+    { id: 'pf1', name: 'One', show: true },
+    { id: 'pf2', name: 'Two', show: true }
+  ]));
+  window.localStorage.setItem('portfolioData_pf1', JSON.stringify([{ ticker: 'AAA', quantity: 1, purchasePrice: 1, lastPrice: 1, tradeDate: '2024-05-01', currency: 'USD' }]));
+  window.localStorage.setItem('portfolioData_pf2', JSON.stringify([{ ticker: 'BBB', quantity: 1, purchasePrice: 1, lastPrice: 1, tradeDate: '2024-05-01', currency: 'USD' }]));
+
+  const pmCode = fs.readFileSync(path.resolve(__dirname, '../app/js/portfolioManager.js'), 'utf8');
+  vm.runInContext(pmCode, context);
+  vm.runInContext('PortfolioManager.init()', context);
+  await vm.runInContext('PortfolioManager.fetchLastPrices()', context);
+
+  const pf1 = JSON.parse(window.localStorage.getItem('portfolioData_pf1'));
+  const pf2 = JSON.parse(window.localStorage.getItem('portfolioData_pf2'));
+  expect(pf1[0].lastPrice).toBe(111);
+  expect(pf2[0].lastPrice).toBe(222);
+});

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -692,15 +692,20 @@ const PortfolioManager = (function() {
         editTotal.textContent = formatCurrency(qty * price, currency);
     }
 
-    async function fetchLastPrices() {
-        if (investments.length === 0) return;
+    async function updatePortfolioPrices(portfolioId) {
+        const key = getStorageKey(portfolioId);
+        const data = localStorage.getItem(key);
+        if (!data) return;
+        let list;
+        try { list = JSON.parse(data) || []; } catch (e) { list = []; }
+        if (list.length === 0) return;
 
         const priceMap = {};
         const currencyMap = {};
-        const tickers = Array.from(new Set(investments.map(inv => inv.ticker)));
+        const tickers = Array.from(new Set(list.map(inv => inv.ticker)));
 
         const fetches = tickers.map(ticker => {
-            const inv = investments.find(i => i.ticker === ticker);
+            const inv = list.find(i => i.ticker === ticker);
             const curr = inv ? inv.currency || 'USD' : 'USD';
             return fetchQuote(ticker, curr).then(res => {
                 if (res.price !== null) {
@@ -712,14 +717,21 @@ const PortfolioManager = (function() {
 
         await Promise.all(fetches);
 
-        investments.forEach(inv => {
+        list.forEach(inv => {
             if (priceMap[inv.ticker] !== undefined) {
                 inv.lastPrice = priceMap[inv.ticker];
                 inv.currency = currencyMap[inv.ticker] || inv.currency;
             }
         });
 
-        saveData();
+        localStorage.setItem(key, JSON.stringify(list));
+    }
+
+    async function fetchLastPrices() {
+        for (const pf of portfolios) {
+            await updatePortfolioPrices(pf.id);
+        }
+        loadData();
         renderTable();
     }
 
@@ -939,5 +951,5 @@ const PortfolioManager = (function() {
         renderTable();
     }
 
-    return { init, fetchQuote, fetchLastPrices, exportData, importData, deleteAllData };
+    return { init, fetchQuote, fetchLastPrices, exportData, importData, deleteAllData, updatePortfolioPrices };
 })();


### PR DESCRIPTION
## Summary
- add `updatePortfolioPrices` helper for updating prices of a portfolio
- update `fetchLastPrices` to refresh all portfolios and reload current data
- export the new helper from `PortfolioManager`
- add Jest test covering multi-portfolio price updates

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887dd392080832f8ea93e57b310ce9a