### PR TITLE
Ensure edit modal focuses input

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -99,3 +99,24 @@ test('Edit modal focuses name input when opened', () => {
   vm.runInContext('__openEditModal(0)', context);
   expect(dom.window.document.activeElement.id).toBe('edit-name');
 });
+
+test('Add Portfolio prompt focuses text input when opened', () => {
+  const html = `<!DOCTYPE html><html><body>
+    <div id="dialog-modal" class="modal">
+      <div class="modal-content">
+        <span id="dialog-close">&times;</span>
+        <p id="dialog-message"></p>
+        <div id="dialog-input-group" class="form-group">
+          <input type="text" id="dialog-input">
+        </div>
+        <button id="dialog-cancel">No</button>
+        <button id="dialog-ok">Yes</button>
+      </div>
+    </div>`;
+  const dom = new JSDOM(html, {url: 'http://localhost'});
+  const context = vm.createContext(dom.window);
+  const dm = fs.readFileSync(path.resolve(__dirname, '../app/js/dialogManager.js'), 'utf8');
+  vm.runInContext(dm, context);
+  vm.runInContext('DialogManager.prompt("Enter portfolio name:")', context);
+  expect(dom.window.document.activeElement.id).toBe('dialog-input');
+});

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -69,3 +69,33 @@ test('DateUtils.formatDate formats date correctly', () => {
   const result = vm.runInContext('DateUtils.formatDate("2024-05-01")', context);
   expect(result).toBe('01/05/2024');
 });
+
+test('Edit modal focuses name input when opened', () => {
+  const html = `<!DOCTYPE html><html><body>
+    <div id="edit-investment-modal" class="modal">
+      <div class="modal-content">
+        <div id="edit-record-group" style="display:none;">
+          <select id="edit-record-select"></select>
+        </div>
+        <input type="text" id="edit-name">
+        <input type="number" id="edit-quantity">
+        <input type="number" id="edit-purchase-price">
+        <input type="date" id="edit-purchase-date">
+        <input type="number" id="edit-last-price">
+        <select id="edit-currency"></select>
+        <span id="edit-total-value"></span>
+      </div>
+    </div>`;
+  const dom = new JSDOM(html, {url: 'http://localhost'});
+  dom.window.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({ c: 1, currency: 'USD' }) });
+  const context = vm.createContext(dom.window);
+  let pm = fs.readFileSync(path.resolve(__dirname, '../app/js/portfolioManager.js'), 'utf8');
+  pm = pm.replace(
+    'return { init, fetchQuote, fetchLastPrices, exportData, importData, deleteAllData };',
+    'window.__setInvestments = arr => { investments = arr; }; window.__openEditModal = openEditModal; return { init, fetchQuote, fetchLastPrices, exportData, importData, deleteAllData };'
+  );
+  vm.runInContext(pm, context);
+  vm.runInContext('__setInvestments([{ ticker: "AAA", name: "Test", quantity: 1, purchasePrice: 1, lastPrice: 1, tradeDate: "2024-01-01", currency: "USD" }])', context);
+  vm.runInContext('__openEditModal(0)', context);
+  expect(dom.window.document.activeElement.id).toBe('edit-name');
+});

--- a/app/js/dialogManager.js
+++ b/app/js/dialogManager.js
@@ -13,7 +13,6 @@ const DialogManager = (function() {
         if (type === 'prompt') {
             inputGroup.style.display = 'block';
             inputEl.value = def || '';
-            inputEl.focus();
         } else {
             inputGroup.style.display = 'none';
         }
@@ -26,6 +25,7 @@ const DialogManager = (function() {
             okBtn.textContent = actionLabel ? `Yes, ${actionLabel}` : 'Yes';
         }
         modal.style.display = 'flex';
+        if (type === 'prompt') inputEl.focus();
 
         return new Promise(resolve => {
             function cleanup(result) {

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -645,6 +645,7 @@ const PortfolioManager = (function() {
 
         populateEditFields(index);
         editModal.style.display = 'flex';
+        document.getElementById('edit-name').focus();
         fetchQuote(ticker, investments[index].currency || 'USD').then(res => {
             if (res.price !== null) {
                 document.getElementById('edit-last-price').value = res.price;


### PR DESCRIPTION
## Summary
- focus on the first input when opening the edit investment modal
- verify focus behavior in new Jest test

## Testing
- `npm install` (inside app/js)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887dd55f978832faaa405d05842866d