### PR TITLE
Fix pension percent calc with payments

### DIFF
--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -347,7 +347,8 @@ const PensionManager = (function() {
             const ytdPL = entry.value - ytdStart - ytdPayments;
             const ytdPLPct = ytdStart ? (ytdPL / ytdStart) * 100 : 0;
             const totalPL = entry.value - startVal - totalPayments;
-            const totalPLPct = startVal ? (totalPL / startVal) * 100 : 0;
+            const baseAmount = startVal + totalPayments;
+            const totalPLPct = baseAmount ? (totalPL / baseAmount) * 100 : 0;
             prev = entry.value;
             return Object.assign({}, entry, {
                 monthlyPL, monthlyPLPct,


### PR DESCRIPTION
## Summary
- calculate Total % using starting balance plus payments
- expose pension computeStats for tests and add new unit test
- update portfolio manager injection in tests
- stub canvas context in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887ee99cbe4832f84922934b385947c