### PR TITLE
Update docs to reference index.html

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -10,7 +10,7 @@
 
 ### Local Development
 1. Clone the repository
-2. Open `app/financial_dashboard.html` in your preferred editor
+2. Open `app/index.html` in your preferred editor
 3. Open the file in a web browser for testing
 4. Use browser developer tools for debugging
 
@@ -28,8 +28,7 @@
 ```
 personal-finance-dashboard/
 ├── app/
-│   ├── financial_dashboard.html    # Main application file
-│   └── index.html                  # Landing page
+│   └── index.html                  # Main application file
 ├── README.md                  # Project overview
 ├── TECHNICAL_DOCUMENTATION.md # Technical details
 ├── API_REFERENCE.md          # API documentation
@@ -37,7 +36,7 @@ personal-finance-dashboard/
 └── DEVELOPMENT_GUIDE.md      # This file
 ```
 
-### Code Sections in financial_dashboard.html
+### Code Sections in index.html
 1. **HTML Structure** (lines 1-773)
    - Document head with meta tags and title
    - Main application layout

--- a/DOCUMENTATION_SUMMARY.md
+++ b/DOCUMENTATION_SUMMARY.md
@@ -5,7 +5,7 @@ This document provides a comprehensive analysis and documentation package for th
 
 ## Repository Information
 - **Repository**: bgosalci/personal-finance-dashboard
-- **Main File**: app/financial_dashboard.html (single-page application)
+- **Main File**: app/index.html (single-page application)
 - **Architecture**: Vanilla JavaScript with modular IIFE pattern
 - **Size**: ~2,429 lines of code (HTML, CSS, JavaScript combined)
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -4,7 +4,7 @@
 
 ### Opening the Application
 1. Download or clone the repository
-2. Open `app/financial_dashboard.html` in any modern web browser
+2. Open `app/index.html` in any modern web browser
 3. The application will load immediately - no installation required!
 
 ## Navigation


### PR DESCRIPTION
## Summary
- update docs to refer to `app/index.html`
- remove obsolete entry in the development guide's file tree
- rename heading to `Code Sections in index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688912390c38832fbe8ddf353bce61dd