### PR TITLE
Fix duplicate colors in portfolio summary

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -116,3 +116,12 @@ test('settings include stock tracker buttons', () => {
   const btn = doc.getElementById('export-stock-btn');
   expect(btn).not.toBeNull();
 });
+
+test('settings display app version placeholder', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const version = doc.getElementById('app-version');
+  expect(version).not.toBeNull();
+});

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -51,15 +51,19 @@ test('fetchQuote returns price and currency', async () => {
 test('Settings module saves currency to localStorage', () => {
   const html = '<!DOCTYPE html><html><body>' +
     '<select id="base-currency-select"></select>' +
+    '<span id="app-version"></span>' +
     '</body></html>';
   const dom = new JSDOM(html, {url: 'http://localhost'});
   const { window } = dom;
   const context = vm.createContext(window);
+  const verCode = fs.readFileSync(path.resolve(__dirname, '../app/js/appVersion.js'), 'utf8');
+  vm.runInContext(verCode, context);
   const content = fs.readFileSync(path.resolve(__dirname, '../app/js/settings.js'), 'utf8');
   vm.runInContext(content, context);
   vm.runInContext('Settings.init()', context);
   vm.runInContext('document.getElementById("base-currency-select").value = "GBP"; document.getElementById("base-currency-select").dispatchEvent(new window.Event("change"));', context);
   expect(window.localStorage.getItem('pf_base_currency')).toBe('GBP');
+  expect(window.document.getElementById('app-version').textContent).toBe('1.0.1');
 });
 
 test('DateUtils.formatDate formats date correctly', () => {

--- a/app/index.html
+++ b/app/index.html
@@ -806,6 +806,12 @@
                         <button type="button" class="btn btn-danger" id="delete-stock-btn">Delete Data</button>
                     </div>
                 </div>
+
+                <h3 class="section-subtitle">About</h3>
+                <div class="form-group">
+                    <label>Web App Version</label>
+                    <span id="app-version"></span>
+                </div>
             </div>
         </div>
     </div>
@@ -962,6 +968,7 @@
     <script src="js/calculator.js"></script>
     <script src="js/stockTracker.js"></script>
     <script src="js/stockFinance.js"></script>
+    <script src="js/appVersion.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/financialDashboard.js"></script>
     <script src="js/marketStatus.js"></script>

--- a/app/js/appVersion.js
+++ b/app/js/appVersion.js
@@ -1,0 +1,12 @@
+const AppVersion = (function() {
+    'use strict';
+    const VERSION = '1.0.1';
+    function get() {
+        return VERSION;
+    }
+    function display() {
+        const el = document.getElementById('app-version');
+        if (el) el.textContent = VERSION;
+    }
+    return { get, display };
+})();

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -8,6 +8,7 @@ const PortfolioManager = (function() {
     let pieChart = null;
     let barChart = null;
     const COLOR_KEY = 'portfolioColors';
+    const COLOR_INDEX_KEY = 'portfolioColorIndex';
     const COLOR_PALETTE = [
         '#e6194b','#3cb44b','#ffe119','#4363d8','#f58231',
         '#911eb4','#46f0f0','#f032e6','#bcf60c','#fabebe',
@@ -154,14 +155,17 @@ const PortfolioManager = (function() {
             }
         }
         const colorData = localStorage.getItem(COLOR_KEY);
+        const idxData = localStorage.getItem(COLOR_INDEX_KEY);
         if (colorData) {
             try {
                 tickerColors = JSON.parse(colorData) || {};
-                colorIndex = Object.keys(tickerColors).length;
             } catch (e) {
                 tickerColors = {};
-                colorIndex = 0;
             }
+        }
+        colorIndex = parseInt(idxData, 10);
+        if (isNaN(colorIndex)) {
+            colorIndex = Object.keys(tickerColors).length;
         }
         investments.forEach(inv => {
             if (!tickerColors[inv.ticker]) {
@@ -174,6 +178,7 @@ const PortfolioManager = (function() {
         if (summaryMode) return;
         localStorage.setItem(getStorageKey(currentPortfolioId), JSON.stringify(investments));
         localStorage.setItem(COLOR_KEY, JSON.stringify(tickerColors));
+        localStorage.setItem(COLOR_INDEX_KEY, String(colorIndex));
     }
 
     function formatCurrency(value, currency = 'USD') {
@@ -223,6 +228,8 @@ const PortfolioManager = (function() {
         if (!tickerColors[ticker]) {
             tickerColors[ticker] = generateColor(colorIndex);
             colorIndex++;
+            localStorage.setItem(COLOR_KEY, JSON.stringify(tickerColors));
+            localStorage.setItem(COLOR_INDEX_KEY, String(colorIndex));
         }
     }
 
@@ -784,7 +791,7 @@ const PortfolioManager = (function() {
                 const removed = investments.splice(idx, 1)[0];
                 if (removed && !investments.some(inv => inv.ticker === removed.ticker)) {
                     delete tickerColors[removed.ticker];
-                    colorIndex = Object.keys(tickerColors).length;
+                    localStorage.setItem(COLOR_KEY, JSON.stringify(tickerColors));
                 }
                 saveData();
                 renderTable();
@@ -946,6 +953,7 @@ const PortfolioManager = (function() {
         });
         localStorage.removeItem(PORTFOLIO_LIST_KEY);
         localStorage.removeItem(COLOR_KEY);
+        localStorage.removeItem(COLOR_INDEX_KEY);
         portfolios = [];
         investments = [];
         tickerColors = {};

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -336,6 +336,7 @@ const PortfolioManager = (function() {
         } else {
             pieChart.data.labels = labels;
             pieChart.data.datasets[0].data = values;
+            pieChart.data.datasets[0].backgroundColor = colors;
             pieChart.options.plugins.tooltip.callbacks.label = (ctx) => {
                 const pct = total ? (ctx.parsed * 100 / total) : 0;
                 return `${ctx.label}: ${pct.toFixed(2)}%`;
@@ -377,6 +378,7 @@ const PortfolioManager = (function() {
         } else {
             barChart.data.labels = labels;
             barChart.data.datasets[0].data = plPercents;
+            barChart.data.datasets[0].backgroundColor = colors;
             barChart.update();
         }
     }

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -277,6 +277,10 @@ const Settings = (function() {
         } else {
             populateOptions();
         }
+
+        if (typeof AppVersion !== 'undefined' && AppVersion.display) {
+            AppVersion.display();
+        }
     }
 
     return { init, getBaseCurrency, setBaseCurrency };


### PR DESCRIPTION
## Summary
- keep a persistent color index so colors aren't reused
- store color information whenever tickers change

## Testing
- `npm test --prefix app/js`

------
https://chatgpt.com/codex/tasks/task_e_688945011f2c832fa00a4ed9d494a3e0