### PR TITLE
Add spacing above ticker CAGR heading

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -997,6 +997,11 @@
             font-size: 1rem;
         }
 
+        /* Add spacing for subheadings in chart boxes */
+        .chart-box h4 {
+            margin-top: 1rem;
+        }
+
         .chart-box canvas {
             width: 100%;
             height: 300px;


### PR DESCRIPTION
## Summary
- update chart box CSS to add margin before the Ticker CAGR heading

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aac6ff3c0832fa9575b6b3aafc925