### PR TITLE
Fix icon color for mobile menu

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -1028,11 +1028,18 @@
             color: white;
         }
 
+        .icon-btn.menu-toggle ion-icon {
+            fill: var(--primary-blue-dark);
+        }
+
         @media (max-width: 768px) {
             .icon-btn.menu-toggle {
                 display: inline-flex;
                 border: 1px solid var(--primary-blue-dark);
                 color: white;
+            }
+            .icon-btn.menu-toggle ion-icon {
+                fill: var(--primary-blue-dark);
             }
             .summary-toggle {
                 font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- color portfolio menu icon using primary blue

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d475abad4832fbd9112efb8e01b7b