### PR TITLE
feat: apply base currency to calculators

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -75,6 +75,8 @@ Each investment shows:
 
 ## Financial Calculators
 
+All calculator results use the base currency selected in Settings.
+
 ### Loan Calculator
 
 Calculate monthly payments and total interest for loans.

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -108,6 +108,15 @@ test('pension header shows base currency label', () => {
   expect(label).not.toBeNull();
 });
 
+test('loan and investment calculators show base currency labels', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  expect(doc.getElementById('loan-base-currency-label')).not.toBeNull();
+  expect(doc.getElementById('invest-base-currency-label')).not.toBeNull();
+});
+
 test('pension table includes Total Payments column', () => {
   const htmlPath = path.resolve(__dirname, '../app/index.html');
   const html = fs.readFileSync(htmlPath, 'utf8');

--- a/app/index.html
+++ b/app/index.html
@@ -418,7 +418,7 @@
                         <h3 class="calculator-title">Loan Calculator</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label for="loan-principal">Principal Amount ($)</label>
+                                <label for="loan-principal">Principal Amount (<span id="loan-base-currency-label">USD</span>)</label>
                                 <input type="number" id="loan-principal" min="0" step="1000">
                             </div>
                             <div class="form-group">
@@ -433,15 +433,15 @@
                         <div id="loan-results" class="result-display" style="display: none;">
                             <div class="result-item">
                                 <span>Monthly Payment:</span>
-                                <span id="loan-monthly-payment">$0.00</span>
+                                <span id="loan-monthly-payment">0</span>
                             </div>
                             <div class="result-item">
                                 <span>Total Interest:</span>
-                                <span id="loan-total-interest">$0.00</span>
+                                <span id="loan-total-interest">0</span>
                             </div>
                             <div class="result-item">
                                 <span>Total Amount:</span>
-                                <span id="loan-total-amount">$0.00</span>
+                                <span id="loan-total-amount">0</span>
                             </div>
                         </div>
                     </div>
@@ -453,7 +453,7 @@
                         <h3 class="calculator-title">Investment Calculator</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label for="invest-initial">Initial Investment ($)</label>
+                                <label for="invest-initial">Initial Investment (<span id="invest-base-currency-label">USD</span>)</label>
                                 <input type="number" id="invest-initial" min="0" step="1000">
                             </div>
                             <div class="form-group">
@@ -468,11 +468,11 @@
                         <div id="investment-results" class="result-display" style="display: none;">
                             <div class="result-item">
                                 <span>Total Return (Interest):</span>
-                                <span id="invest-total-return">$0.00</span>
+                                <span id="invest-total-return">0</span>
                             </div>
                             <div class="result-item">
                                 <span>Final Value:</span>
-                                <span id="invest-final-value">$0.00</span>
+                                <span id="invest-final-value">0</span>
                             </div>
                         </div>
                         <div id="investment-growth-container" class="table-container" style="display: none; margin-top: 1rem;">

--- a/app/js/calculator.js
+++ b/app/js/calculator.js
@@ -4,9 +4,12 @@ const Calculator = (function() {
     let currentFairValueSection = 'dcf';
     
     function formatCurrency(amount) {
+        const currency = Settings && typeof Settings.getBaseCurrency === 'function'
+            ? Settings.getBaseCurrency()
+            : 'USD';
         return new Intl.NumberFormat('en-US', {
             style: 'currency',
-            currency: 'USD',
+            currency,
             minimumFractionDigits: 2
         }).format(amount);
     }
@@ -17,6 +20,24 @@ const Calculator = (function() {
 
     function formatNumber(num) {
         return num.toFixed(2);
+    }
+
+    function updateCurrencyDisplays() {
+        const currency = Settings && typeof Settings.getBaseCurrency === 'function'
+            ? Settings.getBaseCurrency()
+            : 'USD';
+        const loanLabel = document.getElementById('loan-base-currency-label');
+        const investLabel = document.getElementById('invest-base-currency-label');
+        if (loanLabel) loanLabel.textContent = currency;
+        if (investLabel) investLabel.textContent = currency;
+        ['loan-monthly-payment', 'loan-total-interest', 'loan-total-amount'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = formatCurrency(0);
+        });
+        ['invest-total-return', 'invest-final-value'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = formatCurrency(0);
+        });
     }
 
     // Sub-Tab Management
@@ -347,6 +368,9 @@ const Calculator = (function() {
     })();
 
     function init() {
+        updateCurrencyDisplays();
+        document.addEventListener('baseCurrencyChanged', updateCurrencyDisplays);
+
         // Initialize sub-tab navigation
         const subTabs = document.querySelectorAll('.sub-nav-tab');
         subTabs.forEach(tab => {

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -42,6 +42,7 @@ const Settings = (function() {
         if (!select) return;
         select.addEventListener('change', () => {
             save(select.value);
+            document.dispatchEvent(new CustomEvent('baseCurrencyChanged', { detail: select.value }));
         });
 
         const exportBtn = document.getElementById('export-pensions-btn');


### PR DESCRIPTION
## Summary
- use selected base currency when formatting calculator results
- display base currency labels for loan and investment inputs
- document base-currency behavior and add tests

## Testing
- `cd app/js && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890df72704c832f939c75caef6cbc66