### PR TITLE
Format API stock prices and numeric inputs

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -99,10 +99,10 @@ test('Edit modal focuses name input when opened', () => {
           <select id="edit-record-select"></select>
         </div>
         <input type="text" id="edit-name">
-        <input type="number" id="edit-quantity">
-        <input type="number" id="edit-purchase-price">
+        <input type="text" id="edit-quantity">
+        <input type="text" id="edit-purchase-price">
         <input type="date" id="edit-purchase-date">
-        <input type="number" id="edit-last-price">
+        <input type="text" id="edit-last-price">
         <select id="edit-currency"></select>
         <span id="edit-total-value"></span>
       </div>

--- a/app/index.html
+++ b/app/index.html
@@ -140,11 +140,11 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-quantity">Quantity</label>
-                                    <input type="number" step="0.0001" id="investment-quantity" required>
+                                    <input type="text" inputmode="decimal" id="investment-quantity" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-purchase-price">Purchase Price</label>
-                                    <input type="number" step="0.01" id="investment-purchase-price" required>
+                                    <input type="text" inputmode="decimal" id="investment-purchase-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-purchase-date">Purchase Date</label>
@@ -152,7 +152,7 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-last-price">Last Price</label>
-                                    <input type="number" step="0.01" id="investment-last-price" required>
+                                    <input type="text" inputmode="decimal" id="investment-last-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="investment-currency">Currency</label>
@@ -192,11 +192,11 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-quantity">Quantity</label>
-                                    <input type="number" step="0.0001" id="edit-quantity" required>
+                                    <input type="text" inputmode="decimal" id="edit-quantity" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-purchase-price">Purchase Price</label>
-                                    <input type="number" step="0.01" id="edit-purchase-price" required>
+                                    <input type="text" inputmode="decimal" id="edit-purchase-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-purchase-date">Purchase Date</label>
@@ -204,7 +204,7 @@
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-last-price">Last Price</label>
-                                    <input type="number" step="0.01" id="edit-last-price" required>
+                                    <input type="text" inputmode="decimal" id="edit-last-price" required>
                                 </div>
                                 <div class="form-group">
                                     <label for="edit-currency">Currency</label>


### PR DESCRIPTION
## Summary
- format API-driven stock quotes to two decimal places
- apply comma-separated formatting to numeric inputs and portfolio tables
- adjust tests for new text-based number fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893af1edb58832f9ffec3d644d5ea0d