### PR TITLE
Add principal column to portfolio view

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -40,6 +40,15 @@ test('portfolio table includes currency column', () => {
   expect(headers).toContain('Currency');
 });
 
+test('portfolio table includes principal column', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const headers = Array.from(doc.querySelectorAll('#portfolio-table thead th')).map(th => th.textContent.trim());
+  expect(headers).toContain('Principal');
+});
+
 test('investment forms allow selecting currency', () => {
   const htmlPath = path.resolve(__dirname, '../app/index.html');
   const html = fs.readFileSync(htmlPath, 'utf8');

--- a/app/index.html
+++ b/app/index.html
@@ -75,6 +75,7 @@
                                 <th>Currency</th>
                                 <th>Name</th>
                                 <th>Purchase Price</th>
+                                <th>Principal</th>
                                 <th>Quantity</th>
                                 <th>Last Price</th>
                                 <th>Value</th>
@@ -86,7 +87,7 @@
                         <tbody id="portfolio-body"></tbody>
                         <tfoot>
                             <tr class="summary-row" id="portfolio-total-row">
-                                <td colspan="6">Total (<span id="portfolio-base-currency-label">USD</span>)</td>
+                                <td colspan="7">Total (<span id="portfolio-base-currency-label">USD</span>)</td>
                                 <td id="portfolio-total-value" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-pl" class="number-cell">$0.00</td>
                                 <td id="portfolio-total-plpct" class="number-cell">0.00%</td>

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -533,6 +533,7 @@ const PortfolioManager = (function() {
                 <td>${inv.currency || ''}</td>
                 <td>${inv.name}</td>
                 <td class="number-cell">${formatCurrency(inv.purchasePrice, inv.currency)}</td>
+                <td class="number-cell principal-cell"></td>
                 <td class="number-cell">${inv.quantity}</td>
                 <td class="number-cell">${formatCurrency(inv.lastPrice, inv.currency)}</td>
                 <td class="value-cell"></td>
@@ -564,6 +565,7 @@ const PortfolioManager = (function() {
             const pl = value - cost;
             const plPct = cost ? (pl / cost) * 100 : 0;
 
+            row.querySelector('.principal-cell').textContent = formatCurrency(cost, inv.currency);
             row.querySelector('.value-cell').textContent = formatCurrency(value, inv.currency);
             row.querySelector('.pl-cell').textContent = formatCurrency(pl, inv.currency);
             row.querySelector('.pl-cell').className = 'pl-cell ' + (pl >= 0 ? 'growth-positive' : 'growth-negative');


### PR DESCRIPTION
## Summary
- show principal cost in portfolio table alongside purchase price
- compute and display principal automatically for each holding
- verify portfolio table now includes a principal column via unit test

## Testing
- `npm test --prefix app/js`

------
https://chatgpt.com/codex/tasks/task_e_6897436ba814832f907fb6b903ac7efa