### PR TITLE
feat: customize portfolio column labels

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -309,6 +309,23 @@ Creates a performance comparison chart.
 
 ---
 
+### PortfolioColumns
+
+Handles customizable column labels for the portfolio table.
+
+#### Methods
+
+##### `init()`
+Applies stored column labels to the table header.
+
+##### `getLabels()`
+Returns current column label mappings.
+
+##### `setLabels(labels)`
+Saves new labels to localStorage and updates the table.
+
+---
+
 ## Utility Functions
 
 ### Data Validation
@@ -508,6 +525,7 @@ const CONFIG = {
 Users can customize various aspects of the application through the settings interface or by modifying the configuration object.
 
 ## Latest Changes
+- Added PortfolioColumns module for customizable portfolio headers.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio-wide price refresh capability.

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -613,6 +613,7 @@ For offline use:
 This development guide should help you understand the codebase structure, development patterns, and best practices for maintaining and extending the Personal Finance Dashboard application.
 
 ## Latest Changes
+- Portfolio column labels configurable through Settings.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio-wide price refresh capability.

--- a/DOCUMENTATION_SUMMARY.md
+++ b/DOCUMENTATION_SUMMARY.md
@@ -214,6 +214,7 @@ This documentation package provides everything needed to understand, use, mainta
 This comprehensive documentation package ensures the Personal Finance Dashboard codebase is well-documented, maintainable, and accessible to users and developers at all levels.
 
 ## Latest Changes
+- Portfolio column labels editable via settings dialog.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio-wide price refresh capability.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Personal Finance Dashboard is designed as a single HTML file application tha
 - Investment summary with total values, returns, and transaction history
 - Portfolio totals automatically convert all holdings to your chosen base currency
 - Drag-and-drop reordering of portfolio positions
+- Customize portfolio column labels directly from the Settings tab
 
 ### 🧮 Financial Calculators
 - **Loan Calculator**: Monthly payments, total interest, amortization schedules
@@ -304,6 +305,7 @@ This project is open source and available under the MIT License.
 - **Jest & JSDOM** - For reliable testing infrastructure
 
 ## Latest Changes
+- Portfolio column labels can now be edited from Settings.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio-wide price refresh capability.

--- a/RULES.md
+++ b/RULES.md
@@ -9,6 +9,7 @@ This file outlines basic rules and coding standards for the Personal Finance Das
 - Keep documentation up to date with code changes.
 - Respect the `.gitignore` settings; do not commit dependencies or local build artifacts.
 - Use the built-in `DialogManager` for all alerts, prompts, and confirmation dialogs.
+- Customize portfolio table headers only through the `PortfolioColumns` module.
 
 ## Community Standards
 - Be respectful and collaborative.

--- a/TECHNICAL_DOCUMENTATION.md
+++ b/TECHNICAL_DOCUMENTATION.md
@@ -65,6 +65,14 @@ const investment = {
 };
 ```
 
+### PortfolioColumns
+**Purpose**: Manages customizable labels for portfolio table columns.
+
+**Key Methods**:
+- `init()`: Applies saved column labels on load.
+- `getLabels()`: Retrieves current label mapping.
+- `setLabels(obj)`: Persists new labels and updates the table header.
+
 ### 3. Calculator
 **Location**: Lines 1609-1977
 **Purpose**: Provides various financial calculation tools
@@ -370,6 +378,7 @@ No build process required - the application runs directly in the browser.
 5. Implement proper state management
 
 ## Latest Changes
+- Portfolio column labels are customizable with new PortfolioColumns module.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio-wide price refresh capability.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -206,6 +206,12 @@ To start fresh:
 3. The selection is saved automatically and will be used across the application
 4. Exchange rates refresh once a day so your totals stay accurate
 
+### Editing Portfolio Column Labels
+
+1. Open the **Settings** tab
+2. In the **Portfolio** section, click **Edit Column Labels**
+3. Enter your preferred header names and save
+
 ## Tips for Best Results
 
 ### Portfolio Management Tips
@@ -323,6 +329,7 @@ A: Each browser stores its own data. Different users would need separate browser
 A: Update investment prices weekly or monthly for accurate tracking. More frequent updates provide better insights.
 
 ## Latest Changes
+- Portfolio column headers are now editable from the Settings tab.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio-wide price refresh capability.

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -18,6 +18,7 @@ test('FinancialDashboard global object exists with init and removeTicker', () =>
     'calculator.js',
     'stockTracker.js',
     'stockFinance.js',
+    'portfolioColumns.js',
     'settings.js',
     'forexData.js',
     'financialDashboard.js',
@@ -80,7 +81,7 @@ test('Settings module saves currency to localStorage', () => {
   vm.runInContext('Settings.init()', context);
   vm.runInContext('document.getElementById("base-currency-select").value = "GBP"; document.getElementById("base-currency-select").dispatchEvent(new window.Event("change"));', context);
   expect(window.localStorage.getItem('pf_base_currency')).toBe('GBP');
-  expect(window.document.getElementById('app-version').textContent).toBe('1.0.1');
+  expect(window.document.getElementById('app-version').textContent).toBe('1.1.1');
 });
 
 test('DateUtils.formatDate formats date correctly', () => {

--- a/agent.md
+++ b/agent.md
@@ -809,3 +809,4 @@ This guide should be used alongside the comprehensive [DEVELOPMENT_GUIDE.md](DEV
 - `.gitignore` updated to keep repos clean.
 - Contribution rules summarized in [RULES.md](RULES.md).
 - Documentation checklist now includes updating `DEVELOPMENT_GUIDE.md` for new features or architectural changes.
+- Portfolio column labels can be customized through Settings.

--- a/app/index.html
+++ b/app/index.html
@@ -71,17 +71,17 @@
                     <table class="data-table" id="portfolio-table">
                         <thead>
                             <tr>
-                                <th>Ticker</th>
-                                <th>Currency</th>
-                                <th>Name</th>
-                                <th>Purchase Price</th>
-                                <th>Principal</th>
-                                <th>Quantity</th>
-                                <th>Last Price</th>
-                                <th>Value</th>
-                                <th>P&amp;L</th>
-                                <th>P&amp;L %</th>
-                                <th>Actions</th>
+                                <th id="col-ticker">Ticker</th>
+                                <th id="col-currency">Currency</th>
+                                <th id="col-name">Name</th>
+                                <th id="col-purchasePrice">Purchase Price</th>
+                                <th id="col-principal">Principal</th>
+                                <th id="col-quantity">Quantity</th>
+                                <th id="col-lastPrice">Last Price</th>
+                                <th id="col-value">Value</th>
+                                <th id="col-pl">P&amp;L</th>
+                                <th id="col-plPct">P&amp;L %</th>
+                                <th id="col-actions">Actions</th>
                             </tr>
                         </thead>
                         <tbody id="portfolio-body"></tbody>
@@ -814,6 +814,7 @@
                     <div class="button-row">
                         <button type="button" class="btn btn-secondary" id="export-portfolio-btn">Export Portfolio</button>
                         <button type="button" class="btn btn-secondary" id="import-portfolio-btn">Import Portfolio</button>
+                        <button type="button" class="btn btn-secondary" id="edit-portfolio-labels-btn">Edit Column Labels</button>
                         <button type="button" class="btn btn-danger" id="delete-portfolio-btn">Delete Portfolio</button>
                     </div>
                 </div>
@@ -920,6 +921,25 @@
         </div>
     </div>
 
+    <!-- Edit Portfolio Column Labels Modal -->
+    <div id="portfolio-labels-modal" class="modal">
+        <div class="modal-content">
+            <h3>Edit Portfolio Column Labels</h3>
+            <form id="portfolio-labels-form">
+                <table class="data-table">
+                    <thead>
+                        <tr><th>Current</th><th>New Label</th></tr>
+                    </thead>
+                    <tbody id="portfolio-labels-body"></tbody>
+                </table>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn-secondary" id="cancel-portfolio-labels">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
     <!-- Export Stock Data Modal -->
     <div id="export-stock-modal" class="modal">
         <div class="modal-content">
@@ -988,6 +1008,7 @@
     <script src="js/calculator.js"></script>
     <script src="js/stockTracker.js"></script>
     <script src="js/stockFinance.js"></script>
+    <script src="js/portfolioColumns.js"></script>
     <script src="js/appVersion.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/financialDashboard.js"></script>

--- a/app/js/appVersion.js
+++ b/app/js/appVersion.js
@@ -1,6 +1,6 @@
 const AppVersion = (function() {
     'use strict';
-    const VERSION = '1.0.1';
+    const VERSION = '1.1.1';
     function get() {
         return VERSION;
     }

--- a/app/js/financialDashboard.js
+++ b/app/js/financialDashboard.js
@@ -4,6 +4,7 @@ const FinancialDashboard = (function() {
     function init() {
         TabManager.init();
         Settings.init();
+        PortfolioColumns.init();
         PortfolioManager.init();
         PensionManager.init();
         Calculator.init();

--- a/app/js/package-lock.json
+++ b/app/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-finance-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-finance-dashboard",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "devDependencies": {
         "jest": "^29.7.0",
         "jsdom": "^22.1.0"

--- a/app/js/package.json
+++ b/app/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-finance-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Personal Finance Dashboard",
   "scripts": {
     "test": "jest"

--- a/app/js/portfolioColumns.js
+++ b/app/js/portfolioColumns.js
@@ -1,0 +1,71 @@
+const PortfolioColumns = (function() {
+    'use strict';
+    const STORAGE_KEY = 'pf_portfolio_columns';
+    const DEFAULT_LABELS = {
+        ticker: 'Ticker',
+        currency: 'Currency',
+        name: 'Name',
+        purchasePrice: 'Purchase Price',
+        principal: 'Principal',
+        quantity: 'Quantity',
+        lastPrice: 'Last Price',
+        value: 'Value',
+        pl: 'P&L',
+        plPct: 'P&L %',
+        actions: 'Actions'
+    };
+
+    function load() {
+        try {
+            const data = JSON.parse(localStorage.getItem(STORAGE_KEY));
+            if (data && typeof data === 'object') {
+                const labels = { ...DEFAULT_LABELS, ...data };
+                // save merged labels to ensure migration of new keys
+                save(labels);
+                return labels;
+            }
+        } catch (e) {}
+        return { ...DEFAULT_LABELS };
+    }
+
+    function save(labels) {
+        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(labels)); } catch (e) {}
+    }
+
+    function apply(labels) {
+        const lbls = labels || load();
+        const map = {
+            ticker: 'col-ticker',
+            currency: 'col-currency',
+            name: 'col-name',
+            purchasePrice: 'col-purchasePrice',
+            principal: 'col-principal',
+            quantity: 'col-quantity',
+            lastPrice: 'col-lastPrice',
+            value: 'col-value',
+            pl: 'col-pl',
+            plPct: 'col-plPct',
+            actions: 'col-actions'
+        };
+        Object.keys(map).forEach(key => {
+            const el = document.getElementById(map[key]);
+            if (el) el.textContent = lbls[key];
+        });
+    }
+
+    function init() {
+        apply();
+    }
+
+    function getLabels() {
+        return load();
+    }
+
+    function setLabels(newLabels) {
+        const labels = { ...load(), ...newLabels };
+        save(labels);
+        apply(labels);
+    }
+
+    return { init, getLabels, setLabels, DEFAULT_LABELS };
+})();

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -71,6 +71,11 @@ const Settings = (function() {
         const impPortfolioFile = document.getElementById('import-portfolio-file');
         const impPortfolioCancel = document.getElementById('cancel-import-portfolio');
         const delPortfolioBtn = document.getElementById('delete-portfolio-btn');
+        const editLabelsBtn = document.getElementById('edit-portfolio-labels-btn');
+        const labelsModal = document.getElementById('portfolio-labels-modal');
+        const labelsForm = document.getElementById('portfolio-labels-form');
+        const labelsBody = document.getElementById('portfolio-labels-body');
+        const labelsCancel = document.getElementById('cancel-portfolio-labels');
         const expStockBtn = document.getElementById('export-stock-btn');
         const impStockBtn = document.getElementById('import-stock-btn');
         const delStockBtn = document.getElementById('delete-stock-btn');
@@ -222,6 +227,43 @@ const Settings = (function() {
             reader.readAsText(file);
         }
 
+        function openLabels() {
+            const labels = PortfolioColumns.getLabels();
+            labelsBody.innerHTML = '';
+            Object.keys(PortfolioColumns.DEFAULT_LABELS).forEach(key => {
+                const tr = document.createElement('tr');
+                const tdCur = document.createElement('td');
+                tdCur.textContent = labels[key];
+                const tdNew = document.createElement('td');
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.id = 'label-input-' + key;
+                input.value = labels[key];
+                tdNew.appendChild(input);
+                tr.appendChild(tdCur);
+                tr.appendChild(tdNew);
+                labelsBody.appendChild(tr);
+            });
+            labelsModal.style.display = 'flex';
+            const firstInput = labelsBody.querySelector('input');
+            if (firstInput) firstInput.focus();
+        }
+
+        function closeLabels() {
+            labelsModal.style.display = 'none';
+        }
+
+        function saveLabels(e) {
+            e.preventDefault();
+            const newLabels = {};
+            Object.keys(PortfolioColumns.DEFAULT_LABELS).forEach(key => {
+                const input = document.getElementById('label-input-' + key);
+                newLabels[key] = input.value.trim() || PortfolioColumns.DEFAULT_LABELS[key];
+            });
+            PortfolioColumns.setLabels(newLabels);
+            closeLabels();
+        }
+
         if (expPortfolioBtn) expPortfolioBtn.addEventListener('click', openPortfolioExport);
         if (expPortfolioCancel) expPortfolioCancel.addEventListener('click', closePortfolioExport);
         if (expPortfolioDownload) expPortfolioDownload.addEventListener('click', downloadPortfolioExport);
@@ -241,6 +283,11 @@ const Settings = (function() {
         if (impStockCancel) impStockCancel.addEventListener('click', closeStockImport);
         if (impStockForm) impStockForm.addEventListener('submit', handleStockImport);
         if (impStockModal) impStockModal.addEventListener('click', e => { if (e.target === impStockModal) closeStockImport(); });
+
+        if (editLabelsBtn) editLabelsBtn.addEventListener('click', openLabels);
+        if (labelsCancel) labelsCancel.addEventListener('click', closeLabels);
+        if (labelsForm) labelsForm.addEventListener('submit', saveLabels);
+        if (labelsModal) labelsModal.addEventListener('click', e => { if (e.target === labelsModal) closeLabels(); });
 
         if (delPensionsBtn) {
             delPensionsBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- allow editing portfolio column headers from Settings
- persist custom labels in localStorage with PortfolioColumns module
- bump app version to 1.1.1 and document new feature

## Testing
- `cd app/js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974b733b84832f88ab3065be76e9ad