### PR TITLE
Style currency dropdown to fit options

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -265,6 +265,11 @@
             resize: vertical;
         }
 
+        #base-currency-select {
+            width: fit-content;
+            align-self: flex-start;
+        }
+
         .form-group input:focus, .form-group select:focus {
             outline: none;
             border-color: var(--primary-blue);


### PR DESCRIPTION
## Summary
- Fit base currency selector width to its options

## Testing
- `cd app/js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68975dce43a4832fb6a0656920116bac