### PR TITLE
feat: shrink language selector and add flag emoji

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -270,6 +270,11 @@
             align-self: flex-start;
         }
 
+        #language-select {
+            width: fit-content;
+            align-self: flex-start;
+        }
+
         .form-group input:focus, .form-group select:focus {
             outline: none;
             border-color: var(--primary-blue);

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -48,10 +48,19 @@ const Settings = (function() {
 
         const langSelect = document.getElementById('language-select');
         if (langSelect) {
+            const localeFlags = {
+                en: '🇬🇧',
+                es: '🇪🇸',
+                fr: '🇫🇷',
+                de: '🇩🇪',
+                sq: '🇦🇱',
+                pseudo: '🏳️'
+            };
             I18n.availableLocales.forEach(l => {
                 const opt = document.createElement('option');
                 opt.value = l;
-                opt.textContent = l;
+                const flag = localeFlags[l] || '';
+                opt.textContent = flag ? `${flag} ${l}` : l;
                 langSelect.appendChild(opt);
             });
             langSelect.value = I18n.getLocale();


### PR DESCRIPTION
## Summary
- shrink language selector to fit its options
- show locale flags using emoji in language dropdown

## Testing
- `npm test --prefix app/js`


------
https://chatgpt.com/codex/tasks/task_e_68977cdaafac832f99a9fdfb5f1cbc45