### PR TITLE
Remove language import/export buttons

### DIFF
--- a/I18N_README.md
+++ b/I18N_README.md
@@ -12,8 +12,5 @@ The Settings tab provides a language selector and RTL toggle. Chosen locale and 
 
 If the app is opened directly from the filesystem (`file://`), locale files cannot be fetched due to browser restrictions. In that case the built-in English translations are used automatically so the interface remains functional offline.
 
-## Export/Import
-Language files can be exported and imported from the Settings tab for custom localisation.
-
 ## Pseudolocalisation
 Select the `pseudo` locale to enable pseudolocalisation for QA.

--- a/app/index.html
+++ b/app/index.html
@@ -808,13 +808,6 @@
                 <div class="form-group">
                     <label><input type="checkbox" id="rtl-toggle"> <span data-i18n="settings.rtlToggle">Enable RTL</span></label>
                 </div>
-                <div class="form-group">
-                    <div class="button-row">
-                        <button type="button" class="btn btn-secondary" id="export-lang-btn" data-i18n="settings.exportLang">Export Language</button>
-                        <button type="button" class="btn btn-secondary" id="import-lang-btn" data-i18n="settings.importLang">Import Language</button>
-                        <input type="file" id="import-lang-file" accept=".json" style="display:none">
-                    </div>
-                </div>
                 <h3 class="section-subtitle" data-i18n="settings.sectionTitles.pension">Pension</h3>
                 <div class="form-group">
                     <div class="button-row">

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -81,8 +81,6 @@ const I18n = (function() {
             "deleteStock": "Delete Data",
             "versionLabel": "Web App Version",
             "languageLabel": "Language",
-            "exportLang": "Export Language",
-            "importLang": "Import Language",
             "rtlToggle": "Enable RTL"
         },
         "common": {

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -76,37 +76,6 @@ const Settings = (function() {
             });
         }
 
-        const exportLangBtn = document.getElementById('export-lang-btn');
-        const importLangBtn = document.getElementById('import-lang-btn');
-        const importLangFile = document.getElementById('import-lang-file');
-
-        if (exportLangBtn) {
-            exportLangBtn.addEventListener('click', () => {
-                const data = I18n.exportLocale();
-                const blob = new Blob([data], { type: 'application/json' });
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(blob);
-                a.download = 'locale-' + I18n.getCurrentLocale() + '.json';
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(a.href);
-            });
-        }
-
-        if (importLangBtn && importLangFile) {
-            importLangBtn.addEventListener('click', () => importLangFile.click());
-            importLangFile.addEventListener('change', () => {
-                const file = importLangFile.files[0];
-                if (!file) return;
-                const reader = new FileReader();
-                reader.onload = () => {
-                    I18n.importLocale(reader.result);
-                };
-                reader.readAsText(file);
-            });
-        }
-
         const exportBtn = document.getElementById('export-pensions-btn');
         const importBtn = document.getElementById('import-pensions-btn');
         const exportModal = document.getElementById('export-pensions-modal');

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -72,8 +72,6 @@
     "deleteStock": "Delete Data",
     "versionLabel": "Web App Version",
     "languageLabel": "Language",
-    "exportLang": "Export Language",
-    "importLang": "Import Language",
     "rtlToggle": "Enable RTL"
   },
   "common": {

--- a/app/locales/sq.json
+++ b/app/locales/sq.json
@@ -74,8 +74,6 @@
       "deleteStock": "Fshi të Dhënat",
       "versionLabel": "Versioni i Aplikacionit Web",
       "languageLabel": "Gjuha",
-      "exportLang": "Eksporto Gjuhën",
-      "importLang": "Importo Gjuhën",
       "rtlToggle": "Aktivizo RTL"
     },
     "common": {


### PR DESCRIPTION
## Summary
- Drop language import/export controls from Settings.
- Remove related event listeners and i18n strings.
- Update localization docs to reflect absence of language import/export.

## Testing
- `npm test --prefix app/js`


------
https://chatgpt.com/codex/tasks/task_e_6897826d4110832fb73c16a985a84cdc