### PR TITLE
Add pension translations and summary label

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -258,14 +258,14 @@
             <!-- Pension Tab -->
             <div id="pension" class="tab-content">
                 <div class="section-header">
-                    <h2 class="section-title">Pension</h2>
+                    <h2 class="section-title" data-i18n="pension.title">Pension</h2>
                     <div class="pension-actions">
                         <div class="action-buttons">
-                            <button class="btn btn-primary" id="add-pension-entry-btn">Add Entry</button>
-                            <button class="btn btn-secondary" id="add-pension-btn">Add Pension</button>
-                            <button class="btn btn-secondary" id="remove-pension-btn">Remove Pension</button>
-                            <button class="btn btn-secondary" id="pension-chart-btn">View Chart</button>
-                            <label class="summary-toggle"><input type="checkbox" id="pension-summary-toggle" checked> Show in Summary</label>
+                            <button class="btn btn-primary" id="add-pension-entry-btn" data-i18n="pension.actions.addEntry">Add Entry</button>
+                            <button class="btn btn-secondary" id="add-pension-btn" data-i18n="pension.actions.addPension">Add Pension</button>
+                            <button class="btn btn-secondary" id="remove-pension-btn" data-i18n="pension.actions.removePension">Remove Pension</button>
+                            <button class="btn btn-secondary" id="pension-chart-btn" data-i18n="pension.actions.viewChart">View Chart</button>
+                            <label class="summary-toggle"><input type="checkbox" id="pension-summary-toggle" checked> <span data-i18n="pension.actions.showInSummary">Show in Summary</span></label>
                         </div>
                     </div>
                 </div>
@@ -274,17 +274,17 @@
                     <table class="data-table" id="pension-table">
                         <thead>
                             <tr>
-                                <th>Date</th>
-                                <th class="payment-col" style="display:none;">Payment (<span id="pension-payment-currency-label">USD</span>)</th>
-                                <th class="total-payment-col" style="display:none;">Total Payments (<span id="pension-total-payment-currency-label">USD</span>)</th>
-                                <th>Current Value (<span id="pension-base-currency-label">USD</span>)</th>
-                                <th>Monthly P&amp;L</th>
-                                <th>Monthly %</th>
-                                <th>YTD P&amp;L</th>
-                                <th>YTD %</th>
-                                <th>Total P&amp;L</th>
-                                <th>Total %</th>
-                                <th>Actions</th>
+                                <th data-i18n="pension.table.date">Date</th>
+                <th class="payment-col" style="display:none;"><span data-i18n="pension.table.payment">Payment</span> (<span id="pension-payment-currency-label">USD</span>)</th>
+                <th class="total-payment-col" style="display:none;"><span data-i18n="pension.table.totalPayments">Total Payments</span> (<span id="pension-total-payment-currency-label">USD</span>)</th>
+                <th><span data-i18n="pension.table.currentValue">Current Value</span> (<span id="pension-base-currency-label">USD</span>)</th>
+                                <th data-i18n="pension.table.monthlyPL">Monthly P&amp;L</th>
+                                <th data-i18n="pension.table.monthlyPct">Monthly %</th>
+                                <th data-i18n="pension.table.ytdPL">YTD P&amp;L</th>
+                                <th data-i18n="pension.table.ytdPct">YTD %</th>
+                                <th data-i18n="pension.table.totalPL">Total P&amp;L</th>
+                                <th data-i18n="pension.table.totalPct">Total %</th>
+                                <th data-i18n="pension.table.actions">Actions</th>
                             </tr>
                         </thead>
                         <tbody id="pension-body"></tbody>
@@ -292,23 +292,23 @@
                 </div>
                 <div class="summary-cards" id="pension-summary-cards" style="display:none;">
                     <div class="summary-card">
-                        <h4>Current CAGR</h4>
+                        <h4 data-i18n="pension.summaryCards.currentCAGR">Current CAGR</h4>
                         <p id="pension-current-cagr"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Best Month</h4>
+                        <h4 data-i18n="pension.summaryCards.bestMonth">Best Month</h4>
                         <p id="pension-best-month"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Worst Month</h4>
+                        <h4 data-i18n="pension.summaryCards.worstMonth">Worst Month</h4>
                         <p id="pension-worst-month"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Best Year</h4>
+                        <h4 data-i18n="pension.summaryCards.bestYear">Best Year</h4>
                         <p id="pension-best-year"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Worst Year</h4>
+                        <h4 data-i18n="pension.summaryCards.worstYear">Worst Year</h4>
                         <p id="pension-worst-year"></p>
                     </div>
                 </div>

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -58,6 +58,36 @@ const I18n = (function() {
                 "years": "Years"
                 }
             },
+            "pension": {
+                "title": "Pension",
+                "actions": {
+                    "addEntry": "Add Entry",
+                    "addPension": "Add Pension",
+                    "removePension": "Remove Pension",
+                    "viewChart": "View Chart",
+                    "showInSummary": "Show in Summary"
+                },
+                "table": {
+                    "date": "Date",
+                    "payment": "Payment",
+                    "totalPayments": "Total Payments",
+                    "currentValue": "Current Value",
+                    "monthlyPL": "Monthly P&L",
+                    "monthlyPct": "Monthly %",
+                    "ytdPL": "YTD P&L",
+                    "ytdPct": "YTD %",
+                    "totalPL": "Total P&L",
+                    "totalPct": "Total %",
+                    "actions": "Actions"
+                },
+                "summaryCards": {
+                    "currentCAGR": "Current CAGR",
+                    "bestMonth": "Best Month",
+                    "worstMonth": "Worst Month",
+                    "bestYear": "Best Year",
+                    "worstYear": "Worst Year"
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "baseCurrency": "Base Currency",
@@ -90,7 +120,8 @@ const I18n = (function() {
                 "file": "File",
                 "cancel": "Cancel",
                 "import": "Import",
-                "export": "Export"
+                "export": "Export",
+                "summary": "Summary"
             }
         },
         "sq": {
@@ -144,6 +175,36 @@ const I18n = (function() {
                 "years": "Vitet"
                 }
             },
+            "pension": {
+                "title": "Pensioni",
+                "actions": {
+                    "addEntry": "Shto Regjistrim",
+                    "addPension": "Shto Pension",
+                    "removePension": "Hiq Pension",
+                    "viewChart": "Shiko Grafik",
+                    "showInSummary": "Shfaq në Përmbledhje"
+                },
+                "table": {
+                    "date": "Data",
+                    "payment": "Pagesa",
+                    "totalPayments": "Pagesat Totale",
+                    "currentValue": "Vlera Aktuale",
+                    "monthlyPL": "Fitimi/Humbja Mujore",
+                    "monthlyPct": "% Mujore",
+                    "ytdPL": "Fitimi/Humbja YTD",
+                    "ytdPct": "% YTD",
+                    "totalPL": "Fitimi/Humbja Totale",
+                    "totalPct": "% Totale",
+                    "actions": "Veprimet"
+                },
+                "summaryCards": {
+                    "currentCAGR": "CAGR Aktual",
+                    "bestMonth": "Muaji Më i Mirë",
+                    "worstMonth": "Muaji Më i Keq",
+                    "bestYear": "Viti Më i Mirë",
+                    "worstYear": "Viti Më i Keq"
+                }
+            },
             "settings": {
                 "title": "Cilësimet",
                 "baseCurrency": "Monedha Bazë",
@@ -176,7 +237,8 @@ const I18n = (function() {
                 "file": "Skedari",
                 "cancel": "Anulo",
                 "import": "Importo",
-                "export": "Eksporto"
+                "export": "Eksporto",
+                "summary": "Përmbledhje"
             }
         },
         "fr": {
@@ -230,6 +292,36 @@ const I18n = (function() {
                 "years": "Années"
                 }
             },
+            "pension": {
+                "title": "Pension",
+                "actions": {
+                    "addEntry": "Ajouter une Entrée",
+                    "addPension": "Ajouter une Pension",
+                    "removePension": "Supprimer la Pension",
+                    "viewChart": "Voir le Graphique",
+                    "showInSummary": "Afficher dans le Résumé"
+                },
+                "table": {
+                    "date": "Date",
+                    "payment": "Paiement",
+                    "totalPayments": "Paiements Totaux",
+                    "currentValue": "Valeur Actuelle",
+                    "monthlyPL": "P&L Mensuel",
+                    "monthlyPct": "% Mensuel",
+                    "ytdPL": "P&L YTD",
+                    "ytdPct": "% YTD",
+                    "totalPL": "P&L Total",
+                    "totalPct": "% Total",
+                    "actions": "Actions"
+                },
+                "summaryCards": {
+                    "currentCAGR": "CAGR Actuel",
+                    "bestMonth": "Meilleur Mois",
+                    "worstMonth": "Pire Mois",
+                    "bestYear": "Meilleure Année",
+                    "worstYear": "Pire Année"
+                }
+            },
             "settings": {
                 "title": "Paramètres",
                 "baseCurrency": "Devise de Base",
@@ -262,7 +354,8 @@ const I18n = (function() {
                 "file": "Fichier",
                 "cancel": "Annuler",
                 "import": "Importer",
-                "export": "Exporter"
+                "export": "Exporter",
+                "summary": "Résumé"
             }
         },
         "de": {
@@ -316,6 +409,36 @@ const I18n = (function() {
                 "years": "Jahre"
                 }
             },
+            "pension": {
+                "title": "Rente",
+                "actions": {
+                    "addEntry": "Eintrag hinzufügen",
+                    "addPension": "Rente hinzufügen",
+                    "removePension": "Rente entfernen",
+                    "viewChart": "Diagramm anzeigen",
+                    "showInSummary": "In Zusammenfassung anzeigen"
+                },
+                "table": {
+                    "date": "Datum",
+                    "payment": "Zahlung",
+                    "totalPayments": "Gesamtzahlungen",
+                    "currentValue": "Aktueller Wert",
+                    "monthlyPL": "Monatlicher G&V",
+                    "monthlyPct": "Monatlich %",
+                    "ytdPL": "G&V seit Jahresbeginn",
+                    "ytdPct": "YTD %",
+                    "totalPL": "Gesamt G&V",
+                    "totalPct": "Gesamt %",
+                    "actions": "Aktionen"
+                },
+                "summaryCards": {
+                    "currentCAGR": "Aktueller CAGR",
+                    "bestMonth": "Bester Monat",
+                    "worstMonth": "Schlechtester Monat",
+                    "bestYear": "Bestes Jahr",
+                    "worstYear": "Schlechtestes Jahr"
+                }
+            },
             "settings": {
                 "title": "Einstellungen",
                 "baseCurrency": "Basiswährung",
@@ -348,7 +471,8 @@ const I18n = (function() {
                 "file": "Datei",
                 "cancel": "Abbrechen",
                 "import": "Importieren",
-                "export": "Exportieren"
+                "export": "Exportieren",
+                "summary": "Zusammenfassung"
             }
         },
         "es": {
@@ -402,6 +526,36 @@ const I18n = (function() {
                 "years": "Años"
                 }
             },
+            "pension": {
+                "title": "Pensión",
+                "actions": {
+                    "addEntry": "Agregar Entrada",
+                    "addPension": "Agregar Pensión",
+                    "removePension": "Eliminar Pensión",
+                    "viewChart": "Ver Gráfico",
+                    "showInSummary": "Mostrar en el Resumen"
+                },
+                "table": {
+                    "date": "Fecha",
+                    "payment": "Pago",
+                    "totalPayments": "Pagos Totales",
+                    "currentValue": "Valor Actual",
+                    "monthlyPL": "P&L Mensual",
+                    "monthlyPct": "% Mensual",
+                    "ytdPL": "P&L YTD",
+                    "ytdPct": "% YTD",
+                    "totalPL": "P&L Total",
+                    "totalPct": "% Total",
+                    "actions": "Acciones"
+                },
+                "summaryCards": {
+                    "currentCAGR": "CAGR Actual",
+                    "bestMonth": "Mejor Mes",
+                    "worstMonth": "Peor Mes",
+                    "bestYear": "Mejor Año",
+                    "worstYear": "Peor Año"
+                }
+            },
             "settings": {
                 "title": "Configuración",
                 "baseCurrency": "Moneda Base",
@@ -434,7 +588,8 @@ const I18n = (function() {
                 "file": "Archivo",
                 "cancel": "Cancelar",
                 "import": "Importar",
-                "export": "Exportar"
+                "export": "Exportar",
+                "summary": "Resumen"
             }
         },
         "it": {
@@ -488,6 +643,36 @@ const I18n = (function() {
                 "years": "Anni"
                 }
             },
+            "pension": {
+                "title": "Pensione",
+                "actions": {
+                    "addEntry": "Aggiungi Voce",
+                    "addPension": "Aggiungi Pensione",
+                    "removePension": "Rimuovi Pensione",
+                    "viewChart": "Visualizza Grafico",
+                    "showInSummary": "Mostra nel Riepilogo"
+                },
+                "table": {
+                    "date": "Data",
+                    "payment": "Pagamento",
+                    "totalPayments": "Pagamenti Totali",
+                    "currentValue": "Valore Attuale",
+                    "monthlyPL": "Utile/Perdita Mensile",
+                    "monthlyPct": "% Mensile",
+                    "ytdPL": "Utile/Perdita YTD",
+                    "ytdPct": "% YTD",
+                    "totalPL": "Utile/Perdita Totale",
+                    "totalPct": "% Totale",
+                    "actions": "Azioni"
+                },
+                "summaryCards": {
+                    "currentCAGR": "CAGR Attuale",
+                    "bestMonth": "Mese Migliore",
+                    "worstMonth": "Mese Peggiore",
+                    "bestYear": "Anno Migliore",
+                    "worstYear": "Anno Peggiore"
+                }
+            },
             "settings": {
                 "title": "Impostazioni",
                 "baseCurrency": "Valuta Base",
@@ -520,10 +705,24 @@ const I18n = (function() {
                 "file": "File",
                 "cancel": "Annulla",
                 "import": "Importa",
-                "export": "Esporta"
+                "export": "Esporta",
+                "summary": "Riepilogo"
             }
         }
     };
+
+    function mergeDeep(target, source) {
+        Object.keys(source).forEach(key => {
+            const src = source[key];
+            if (src && typeof src === 'object' && !Array.isArray(src)) {
+                if (!target[key]) target[key] = {};
+                mergeDeep(target[key], src);
+            } else {
+                target[key] = src;
+            }
+        });
+        return target;
+    }
 
     const availableLocales = Object.keys(DEFAULT_TRANSLATIONS);
     availableLocales.push('pseudo');
@@ -538,35 +737,34 @@ const I18n = (function() {
 
     async function loadLocale(locale) {
         const storeKey = 'locale-' + locale;
+        let loaded = null;
         const cached = localStorage.getItem(storeKey);
         if (cached) {
-            translations = JSON.parse(cached);
-            currentLocale = locale;
-            return;
+            try { loaded = JSON.parse(cached); } catch {}
         }
-
-        if (typeof fetch === 'function' && !isFileProtocol) {
+        if (!loaded && typeof fetch === 'function' && !isFileProtocol) {
             try {
                 const resp = await fetch('locales/' + locale + '.json');
-                if (!resp.ok) throw new Error('Failed to fetch');
-                translations = await resp.json();
-                localStorage.setItem(storeKey, JSON.stringify(translations));
-                currentLocale = locale;
-                return;
+                if (resp.ok) {
+                    loaded = await resp.json();
+                }
             } catch (e) {
                 console.warn('Failed to load locale', locale, e);
             }
         }
-
-        if (DEFAULT_TRANSLATIONS[locale]) {
-            translations = DEFAULT_TRANSLATIONS[locale];
-            localStorage.setItem(storeKey, JSON.stringify(translations));
-            currentLocale = locale;
-            if (locale !== 'en' && !localStorage.getItem('locale-en')) {
-                localStorage.setItem('locale-en', JSON.stringify(DEFAULT_TRANSLATIONS.en));
-            }
-        } else {
+        if (!loaded && DEFAULT_TRANSLATIONS[locale]) {
+            loaded = DEFAULT_TRANSLATIONS[locale];
+        }
+        if (!loaded) {
             await loadLocale('en');
+            return;
+        }
+        const base = DEFAULT_TRANSLATIONS[locale] ? JSON.parse(JSON.stringify(DEFAULT_TRANSLATIONS[locale])) : {};
+        translations = mergeDeep(base, loaded);
+        localStorage.setItem(storeKey, JSON.stringify(translations));
+        currentLocale = locale;
+        if (locale !== 'en' && !localStorage.getItem('locale-en')) {
+            localStorage.setItem('locale-en', JSON.stringify(DEFAULT_TRANSLATIONS.en));
         }
     }
 

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -129,7 +129,7 @@ const PensionManager = (function() {
         pensionTabs.innerHTML = '';
         const summaryTab = document.createElement('button');
         summaryTab.className = 'sub-nav-tab';
-        summaryTab.textContent = 'Summary';
+        summaryTab.textContent = I18n.t('common.summary');
         summaryTab.dataset.id = 'summary';
         pensionTabs.appendChild(summaryTab);
         pensions.forEach(p => {
@@ -429,8 +429,8 @@ const PensionManager = (function() {
         const worstYearEl = document.getElementById('pension-worst-year');
 
         cagrEl.textContent = analysis.cagr ? analysis.cagr.toFixed(2) + '%' : '---';
-        bestMonthEl.textContent = analysis.bestMonth ? `${DateUtils.formatDate(analysis.bestMonth.date)} (${analysis.bestMonth.pct.toFixed(2)}%)` : '---';
-        worstMonthEl.textContent = analysis.worstMonth ? `${DateUtils.formatDate(analysis.worstMonth.date)} (${analysis.worstMonth.pct.toFixed(2)}%)` : '---';
+        bestMonthEl.textContent = analysis.bestMonth ? `${analysis.bestMonth.date} (${analysis.bestMonth.pct.toFixed(2)}%)` : '---';
+        worstMonthEl.textContent = analysis.worstMonth ? `${analysis.worstMonth.date} (${analysis.worstMonth.pct.toFixed(2)}%)` : '---';
         bestYearEl.textContent = analysis.bestYear ? `${analysis.bestYear.year} (${analysis.bestYear.pct.toFixed(2)}%)` : '---';
         worstYearEl.textContent = analysis.worstYear ? `${analysis.worstYear.year} (${analysis.worstYear.pct.toFixed(2)}%)` : '---';
 
@@ -459,7 +459,7 @@ const PensionManager = (function() {
             if (summaryMode) {
                 const ents = getEntriesFor('summary');
                 ents.forEach(en => dateSet.add(en.date));
-                datasets.push({ id: 'summary', name: 'Summary', entries: ents });
+                datasets.push({ id: 'summary', name: I18n.t('common.summary'), entries: ents });
             }
             ids.forEach(id => {
                 const ents = getEntriesFor(id);
@@ -477,7 +477,7 @@ const PensionManager = (function() {
             if (pensionChart) pensionChart.destroy();
             pensionChart = new Chart(chartCanvas.getContext('2d'), {
                 type: 'line',
-                data: { labels: dates.map(DateUtils.formatDate), datasets: chartDatasets },
+                data: { labels: dates, datasets: chartDatasets },
                 options: { responsive: true }
             });
         }
@@ -519,7 +519,7 @@ const PensionManager = (function() {
 
             const type = summaryMode ? summaryInfo.type : pensions.find(p=>p.id===currentPensionId).type;
             row.innerHTML = `
-                <td>${DateUtils.formatDate(st.date)}</td>
+                <td>${st.date}</td>
                 ${type==='payments'?`<td class="number-cell">${formatCurrency(paymentVal, baseCurrency)}</td><td class="number-cell">${formatCurrency(st.totalPayments, baseCurrency)}</td>`:''}
                 <td class="number-cell">${formatCurrency(valueVal, baseCurrency)}</td>
                 <td class="number-cell ${monthlyClass}">${formatCurrency(monthlyVal, baseCurrency)}</td>

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -351,7 +351,7 @@ const PortfolioManager = (function() {
         portfolioTabs.innerHTML = '';
         const summaryTab = document.createElement('button');
         summaryTab.className = 'sub-nav-tab';
-        summaryTab.textContent = 'Summary';
+        summaryTab.textContent = I18n.t('common.summary');
         summaryTab.dataset.id = 'summary';
         portfolioTabs.appendChild(summaryTab);
         portfolios.forEach(p => {


### PR DESCRIPTION
## Summary
- add i18n entries for pension section across supported languages
- translate Summary tab using common key
- wire pension UI elements to translation keys
- merge cached locales with default translations to refresh missing labels
- keep pension dates in ISO format instead of localized

## Testing
- `npm test` *(fails: no package.json)*
- `CI=true npx -y jest` *(fails: Could not find a config file based on provided values)*

------
https://chatgpt.com/codex/tasks/task_e_6897adfbb478832fadfde1e25e69c4fa