### PR TITLE
Localize calculators and stock performance sections

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -406,45 +406,45 @@
 
             <!-- Calculators Tab -->
             <div id="calculators" class="tab-content">
-                <h2 class="section-title">Financial Calculators</h2>
+                <h2 class="section-title" data-i18n="calculators.title">Financial Calculators</h2>
                 
                 <!-- Calculator Sub-Tabs -->
                 <div class="sub-nav-tabs">
-                    <button class="sub-nav-tab active" data-subtab="loan">Loan Calculator</button>
-                    <button class="sub-nav-tab" data-subtab="investment">Investment Calculator</button>
-                    <button class="sub-nav-tab" data-subtab="cagr">CAGR Calculator</button>
-                    <button class="sub-nav-tab" data-subtab="fair-value">Fair Value Calculator</button>
+                    <button class="sub-nav-tab active" data-subtab="loan" data-i18n="calculators.tabs.loan">Loan Calculator</button>
+                    <button class="sub-nav-tab" data-subtab="investment" data-i18n="calculators.tabs.investment">Investment Calculator</button>
+                    <button class="sub-nav-tab" data-subtab="cagr" data-i18n="calculators.tabs.cagr">CAGR Calculator</button>
+                    <button class="sub-nav-tab" data-subtab="fair-value" data-i18n="calculators.tabs.fairValue">Fair Value Calculator</button>
                 </div>
 
                 <!-- Loan Calculator Sub-Tab -->
                 <div id="loan" class="sub-tab-content active">
                     <div class="calculator-section">
-                        <h3 class="calculator-title">Loan Calculator</h3>
+                        <h3 class="calculator-title" data-i18n="calculators.tabs.loan">Loan Calculator</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label for="loan-principal">Principal Amount (<span id="loan-base-currency-label">USD</span>)</label>
+                                <label for="loan-principal"><span data-i18n="calculators.loan.labels.principal">Principal Amount</span> (<span id="loan-base-currency-label">USD</span>)</label>
                                 <input type="number" id="loan-principal" min="0" step="1000">
                             </div>
                             <div class="form-group">
-                                <label for="loan-rate">Annual Interest Rate (%)</label>
+                                <label for="loan-rate" data-i18n="calculators.loan.labels.rate">Annual Interest Rate (%)</label>
                                 <input type="number" id="loan-rate" min="0" max="50" step="0.1">
                             </div>
                             <div class="form-group">
-                                <label for="loan-term">Loan Term (Years)</label>
+                                <label for="loan-term" data-i18n="calculators.loan.labels.term">Loan Term (Years)</label>
                                 <input type="number" id="loan-term" min="1" max="50">
                             </div>
                         </div>
                         <div id="loan-results" class="result-display" style="display: none;">
                             <div class="result-item">
-                                <span>Monthly Payment:</span>
+                                <span data-i18n="calculators.loan.results.monthlyPayment">Monthly Payment:</span>
                                 <span id="loan-monthly-payment">0</span>
                             </div>
                             <div class="result-item">
-                                <span>Total Interest:</span>
+                                <span data-i18n="calculators.loan.results.totalInterest">Total Interest:</span>
                                 <span id="loan-total-interest">0</span>
                             </div>
                             <div class="result-item">
-                                <span>Total Amount:</span>
+                                <span data-i18n="calculators.loan.results.totalAmount">Total Amount:</span>
                                 <span id="loan-total-amount">0</span>
                             </div>
                         </div>
@@ -454,28 +454,28 @@
                 <!-- Investment Calculator Sub-Tab -->
                 <div id="investment" class="sub-tab-content">
                     <div class="calculator-section">
-                        <h3 class="calculator-title">Investment Calculator</h3>
+                        <h3 class="calculator-title" data-i18n="calculators.tabs.investment">Investment Calculator</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label for="invest-initial">Initial Investment (<span id="invest-base-currency-label">USD</span>)</label>
+                                <label for="invest-initial"><span data-i18n="calculators.investment.labels.initial">Initial Investment</span> (<span id="invest-base-currency-label">USD</span>)</label>
                                 <input type="number" id="invest-initial" min="0" step="1000">
                             </div>
                             <div class="form-group">
-                                <label for="invest-rate">Annual Return Rate (%)</label>
+                                <label for="invest-rate" data-i18n="calculators.investment.labels.rate">Annual Return Rate (%)</label>
                                 <input type="number" id="invest-rate" min="0" max="50" step="0.1">
                             </div>
                             <div class="form-group">
-                                <label for="invest-years">Investment Period (Years)</label>
+                                <label for="invest-years" data-i18n="calculators.investment.labels.years">Investment Period (Years)</label>
                                 <input type="number" id="invest-years" min="1" max="100">
                             </div>
                         </div>
                         <div id="investment-results" class="result-display" style="display: none;">
                             <div class="result-item">
-                                <span>Total Return (Interest):</span>
+                                <span data-i18n="calculators.investment.results.totalReturn">Total Return (Interest):</span>
                                 <span id="invest-total-return">0</span>
                             </div>
                             <div class="result-item">
-                                <span>Final Value:</span>
+                                <span data-i18n="calculators.investment.results.finalValue">Final Value:</span>
                                 <span id="invest-final-value">0</span>
                             </div>
                         </div>
@@ -483,9 +483,9 @@
                             <table class="data-table" id="investment-growth-table">
                                 <thead>
                                     <tr>
-                                        <th>Year</th>
-                                        <th>Growth</th>
-                                        <th>Value</th>
+                                        <th data-i18n="calculators.investment.table.year">Year</th>
+                                        <th data-i18n="calculators.investment.table.growth">Growth</th>
+                                        <th data-i18n="calculators.investment.table.value">Value</th>
                                     </tr>
                                 </thead>
                                 <tbody id="investment-growth-body"></tbody>
@@ -497,28 +497,28 @@
                 <!-- CAGR Calculator Sub-Tab -->
                 <div id="cagr" class="sub-tab-content">
                     <div class="calculator-section">
-                        <h3 class="calculator-title">CAGR Calculator</h3>
+                        <h3 class="calculator-title" data-i18n="calculators.tabs.cagr">CAGR Calculator</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label for="cagr-beginning">Beginning Value ($)</label>
+                                <label for="cagr-beginning" data-i18n="calculators.cagr.labels.beginning">Beginning Value ($)</label>
                                 <input type="number" id="cagr-beginning" min="0" step="1000">
                             </div>
                             <div class="form-group">
-                                <label for="cagr-ending">Ending Value ($)</label>
+                                <label for="cagr-ending" data-i18n="calculators.cagr.labels.ending">Ending Value ($)</label>
                                 <input type="number" id="cagr-ending" min="0" step="1000">
                             </div>
                             <div class="form-group">
-                                <label for="cagr-years">Number of Years</label>
+                                <label for="cagr-years" data-i18n="calculators.cagr.labels.years">Number of Years</label>
                                 <input type="number" id="cagr-years" min="1" max="100" step="0.1">
                             </div>
                         </div>
                         <div id="cagr-results" class="result-display" style="display: none;">
                             <div class="result-item">
-                                <span>Total Return:</span>
+                                <span data-i18n="calculators.cagr.results.totalReturn">Total Return:</span>
                                 <span id="cagr-total-return">0.00%</span>
                             </div>
                             <div class="result-item">
-                                <span>Compound Annual Growth Rate (CAGR):</span>
+                                <span data-i18n="calculators.cagr.results.cagr">Compound Annual Growth Rate (CAGR):</span>
                                 <span id="cagr-rate">0.00%</span>
                             </div>
                         </div>
@@ -528,60 +528,60 @@
                 <!-- Fair Value Calculator Sub-Tab -->
                 <div id="fair-value" class="sub-tab-content">
                     <div class="calculator-section">
-                        <h3 class="calculator-title">Fair Value Calculator</h3>
+                        <h3 class="calculator-title" data-i18n="calculators.tabs.fairValue">Fair Value Calculator</h3>
                         
                         <!-- Fair Value Sub-Sections -->
                         <div class="fair-value-sections">
                             <div class="fair-value-nav">
-                                <button class="fair-value-btn active" data-section="dcf">DCF Analysis</button>
-                                <button class="fair-value-btn" data-section="pe">P/E Ratio Analysis</button>
-                                <button class="fair-value-btn" data-section="intrinsic">Intrinsic Value</button>
+                                <button class="fair-value-btn active" data-section="dcf" data-i18n="calculators.fairValue.tabs.dcf">DCF Analysis</button>
+                                <button class="fair-value-btn" data-section="pe" data-i18n="calculators.fairValue.tabs.pe">P/E Ratio Analysis</button>
+                                <button class="fair-value-btn" data-section="intrinsic" data-i18n="calculators.fairValue.tabs.intrinsic">Intrinsic Value</button>
                             </div>
 
                             <!-- DCF Calculator -->
                             <div id="dcf" class="fair-value-section active">
-                                <h4 class="section-subtitle">Discounted Cash Flow (DCF) Analysis</h4>
+                                <h4 class="section-subtitle" data-i18n="calculators.fairValue.dcf.title">Discounted Cash Flow (DCF) Analysis</h4>
                                 <div class="form-grid">
                                     <div class="form-group">
-                                        <label for="dcf-current-fcf">Current Annual Free Cash Flow ($M)</label>
+                                        <label for="dcf-current-fcf"><span data-i18n="calculators.fairValue.dcf.labels.currentFCF">Current Annual Free Cash Flow</span> ($M)</label>
                                         <input type="number" id="dcf-current-fcf" min="0" step="10">
                                     </div>
                                     <div class="form-group">
-                                        <label for="dcf-growth-rate">Growth Rate (%)</label>
+                                        <label for="dcf-growth-rate" data-i18n="calculators.fairValue.dcf.labels.growthRate">Growth Rate (%)</label>
                                         <input type="number" id="dcf-growth-rate" min="0" max="50" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="dcf-terminal-rate">Terminal Growth Rate (%)</label>
+                                        <label for="dcf-terminal-rate" data-i18n="calculators.fairValue.dcf.labels.terminalRate">Terminal Growth Rate (%)</label>
                                         <input type="number" id="dcf-terminal-rate" min="0" max="10" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="dcf-discount-rate">Discount Rate (WACC) (%)</label>
+                                        <label for="dcf-discount-rate" data-i18n="calculators.fairValue.dcf.labels.discountRate">Discount Rate (WACC) (%)</label>
                                         <input type="number" id="dcf-discount-rate" min="0" max="30" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="dcf-years">Projection Years</label>
+                                        <label for="dcf-years" data-i18n="calculators.fairValue.dcf.labels.years">Projection Years</label>
                                         <input type="number" id="dcf-years" min="5" max="20" step="1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="dcf-shares">Shares Outstanding (M)</label>
+                                        <label for="dcf-shares" data-i18n="calculators.fairValue.dcf.labels.shares">Shares Outstanding (M)</label>
                                         <input type="number" id="dcf-shares" min="1" step="0.1">
                                     </div>
                                 </div>
                                 <div id="dcf-results" class="result-display" style="display: none;">
                                     <div class="result-item">
-                                        <span>Enterprise Value:</span>
+                                        <span data-i18n="calculators.fairValue.dcf.results.enterpriseValue">Enterprise Value:</span>
                                         <span id="dcf-enterprise-value">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Present Value of Cash Flows:</span>
+                                        <span data-i18n="calculators.fairValue.dcf.results.pvCashflows">Present Value of Cash Flows:</span>
                                         <span id="dcf-pv-cashflows">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Terminal Value:</span>
+                                        <span data-i18n="calculators.fairValue.dcf.results.terminalValue">Terminal Value:</span>
                                         <span id="dcf-terminal-value">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Intrinsic Value Per Share:</span>
+                                        <span data-i18n="calculators.fairValue.dcf.results.perShare">Intrinsic Value Per Share:</span>
                                         <span id="dcf-per-share">$0.00</span>
                                     </div>
                                 </div>
@@ -589,40 +589,40 @@
 
                             <!-- P/E Ratio Analysis -->
                             <div id="pe" class="fair-value-section">
-                                <h4 class="section-subtitle">P/E Ratio Analysis</h4>
+                                <h4 class="section-subtitle" data-i18n="calculators.fairValue.pe.title">P/E Ratio Analysis</h4>
                                 <div class="form-grid">
                                     <div class="form-group">
-                                        <label for="pe-current-price">Current Stock Price ($)</label>
+                                        <label for="pe-current-price" data-i18n="calculators.fairValue.pe.labels.currentPrice">Current Stock Price ($)</label>
                                         <input type="number" id="pe-current-price" min="0" step="0.01">
                                     </div>
                                     <div class="form-group">
-                                        <label for="pe-eps">Earnings Per Share (EPS) ($)</label>
+                                        <label for="pe-eps" data-i18n="calculators.fairValue.pe.labels.eps">Earnings Per Share (EPS) ($)</label>
                                         <input type="number" id="pe-eps" min="0" step="0.01">
                                     </div>
                                     <div class="form-group">
-                                        <label for="pe-industry-avg">Industry Average P/E</label>
+                                        <label for="pe-industry-avg" data-i18n="calculators.fairValue.pe.labels.industryPE">Industry Average P/E</label>
                                         <input type="number" id="pe-industry-avg" min="0" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="pe-growth-rate">Expected EPS Growth Rate (%)</label>
+                                        <label for="pe-growth-rate" data-i18n="calculators.fairValue.pe.labels.growthRate">Expected EPS Growth Rate (%)</label>
                                         <input type="number" id="pe-growth-rate" min="0" max="100" step="0.1">
                                     </div>
                                 </div>
                                 <div id="pe-results" class="result-display" style="display: none;">
                                     <div class="result-item">
-                                        <span>Current P/E Ratio:</span>
+                                        <span data-i18n="calculators.fairValue.pe.results.currentPE">Current P/E Ratio:</span>
                                         <span id="pe-current-ratio">0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Fair Value (Industry P/E):</span>
+                                        <span data-i18n="calculators.fairValue.pe.results.fairValue">Fair Value (Industry P/E):</span>
                                         <span id="pe-fair-value">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>PEG Ratio:</span>
+                                        <span data-i18n="calculators.fairValue.pe.results.pegRatio">PEG Ratio:</span>
                                         <span id="pe-peg-ratio">0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Valuation Status:</span>
+                                        <span data-i18n="calculators.fairValue.pe.results.valuation">Valuation Status:</span>
                                         <span id="pe-valuation-status">--</span>
                                     </div>
                                 </div>
@@ -630,48 +630,48 @@
 
                             <!-- Intrinsic Value Calculator -->
                             <div id="intrinsic" class="fair-value-section">
-                                <h4 class="section-subtitle">Intrinsic Value Analysis</h4>
+                                <h4 class="section-subtitle" data-i18n="calculators.fairValue.intrinsic.title">Intrinsic Value Analysis</h4>
                                 <div class="form-grid">
                                     <div class="form-group">
-                                        <label for="intrinsic-book-value">Book Value Per Share ($)</label>
+                                        <label for="intrinsic-book-value" data-i18n="calculators.fairValue.intrinsic.labels.bookValue">Book Value Per Share ($)</label>
                                         <input type="number" id="intrinsic-book-value" min="0" step="0.01">
                                     </div>
                                     <div class="form-group">
-                                        <label for="intrinsic-roe">Return on Equity (ROE) (%)</label>
+                                        <label for="intrinsic-roe" data-i18n="calculators.fairValue.intrinsic.labels.roe">Return on Equity (ROE) (%)</label>
                                         <input type="number" id="intrinsic-roe" min="0" max="100" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="intrinsic-dividend-yield">Dividend Yield (%)</label>
+                                        <label for="intrinsic-dividend-yield" data-i18n="calculators.fairValue.intrinsic.labels.dividendYield">Dividend Yield (%)</label>
                                         <input type="number" id="intrinsic-dividend-yield" min="0" max="20" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="intrinsic-required-return">Required Rate of Return (%)</label>
+                                        <label for="intrinsic-required-return" data-i18n="calculators.fairValue.intrinsic.labels.requiredReturn">Required Rate of Return (%)</label>
                                         <input type="number" id="intrinsic-required-return" min="0" max="30" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="intrinsic-growth-rate">Sustainable Growth Rate (%)</label>
+                                        <label for="intrinsic-growth-rate" data-i18n="calculators.fairValue.intrinsic.labels.growthRate">Sustainable Growth Rate (%)</label>
                                         <input type="number" id="intrinsic-growth-rate" min="0" max="50" step="0.1">
                                     </div>
                                     <div class="form-group">
-                                        <label for="intrinsic-eps">Current EPS ($)</label>
+                                        <label for="intrinsic-eps" data-i18n="calculators.fairValue.intrinsic.labels.eps">Current EPS ($)</label>
                                         <input type="number" id="intrinsic-eps" min="0" step="0.01">
                                     </div>
                                 </div>
                                 <div id="intrinsic-results" class="result-display" style="display: none;">
                                     <div class="result-item">
-                                        <span>Graham Number:</span>
+                                        <span data-i18n="calculators.fairValue.intrinsic.results.graham">Graham Number:</span>
                                         <span id="intrinsic-graham">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Dividend Discount Model:</span>
+                                        <span data-i18n="calculators.fairValue.intrinsic.results.ddm">Dividend Discount Model:</span>
                                         <span id="intrinsic-ddm">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Book Value Multiple:</span>
+                                        <span data-i18n="calculators.fairValue.intrinsic.results.bookMultiple">Book Value Multiple:</span>
                                         <span id="intrinsic-book-multiple">$0.00</span>
                                     </div>
                                     <div class="result-item">
-                                        <span>Average Intrinsic Value:</span>
+                                        <span data-i18n="calculators.fairValue.intrinsic.results.average">Average Intrinsic Value:</span>
                                         <span id="intrinsic-average">$0.00</span>
                                     </div>
                                 </div>
@@ -684,24 +684,24 @@
             <!-- Stock Performance Tracker Tab -->
             <div id="stock-tracker" class="tab-content">
                 <div class="section-header">
-                    <h2 class="section-title">Stock Performance Tracker</h2>
+                    <h2 class="section-title" data-i18n="stockTracker.title">Stock Performance Tracker</h2>
                     <div>
-                        <button class="btn btn-secondary" id="edit-stock-btn">Edit</button>
-                        <button class="btn btn-secondary" id="get-stock-last-price-btn">Get The Last Price</button>
+                        <button class="btn btn-secondary" id="edit-stock-btn" data-i18n="stockTracker.actions.edit">Edit</button>
+                        <button class="btn btn-secondary" id="get-stock-last-price-btn" data-i18n="stockTracker.actions.getLastPrice">Get The Last Price</button>
                     </div>
                 </div>
                 
                 <div class="ticker-management" style="display: none;">
                     <div class="form-group">
-                        <label for="ticker-input">Add Stock Ticker</label>
+                        <label for="ticker-input" data-i18n="stockTracker.labels.addStockTicker">Add Stock Ticker</label>
                         <input type="text" id="ticker-input" style="text-transform: uppercase;">
                     </div>
                     <div class="form-group">
-                        <label for="start-year">Starting Year</label>
+                        <label for="start-year" data-i18n="stockTracker.labels.startYear">Starting Year</label>
                         <select id="start-year"></select>
                     </div>
-                    <button class="btn btn-primary" id="add-ticker-btn">Add Ticker</button>
-                    <button class="btn btn-secondary" id="generate-table-btn" style="display: none;">Generate Table</button>
+                    <button class="btn btn-primary" id="add-ticker-btn" data-i18n="stockTracker.actions.addTicker">Add Ticker</button>
+                    <button class="btn btn-secondary" id="generate-table-btn" style="display: none;" data-i18n="stockTracker.actions.generateTable">Generate Table</button>
                 </div>
 
                 <div class="ticker-tags" id="ticker-tags"></div>
@@ -714,19 +714,19 @@
                 </div>
                 <div class="summary-cards" id="stock-summary-cards" style="display: none;">
                     <div class="summary-card">
-                        <h4>Investment Analysis</h4>
+                        <h4 data-i18n="stockTracker.summary.investment">Investment Analysis</h4>
                         <p id="summary-investment-range"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Best Performer</h4>
+                        <h4 data-i18n="stockTracker.summary.best">Best Performer</h4>
                         <p id="summary-best"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Worst Performer</h4>
+                        <h4 data-i18n="stockTracker.summary.worst">Worst Performer</h4>
                         <p id="summary-worst"></p>
                     </div>
                     <div class="summary-card">
-                        <h4>Most Consistent</h4>
+                        <h4 data-i18n="stockTracker.summary.consistent">Most Consistent</h4>
                         <p id="summary-consistent"></p>
                     </div>
                 </div>
@@ -738,8 +738,8 @@
                         <h3 id="chart-popup-title"></h3>
                         <div class="chart-control-panel">
                             <div class="chart-type">
-                                <label><input type="radio" name="chart-type" id="chart-type-price" value="price" checked> Price</label>
-                                <label><input type="radio" name="chart-type" id="chart-type-growth" value="growth"> Growth</label>
+                                <label><input type="radio" name="chart-type" id="chart-type-price" value="price" checked> <span data-i18n="stockTracker.chart.price">Price</span></label>
+                                <label><input type="radio" name="chart-type" id="chart-type-growth" value="growth"> <span data-i18n="stockTracker.chart.growth">Growth</span></label>
                             </div>
                             <div class="ticker-select" id="chart-ticker-select"></div>
                         </div>
@@ -751,34 +751,34 @@
             <!-- Stock Finance Performance Tab -->
             <div id="stock-finance" class="tab-content">
                 <div class="section-header">
-                    <h2 class="section-title">Stock Finance Performance</h2>
+                    <h2 class="section-title" data-i18n="stockFinance.title">Stock Finance Performance</h2>
                 </div>
 
                 <div class="ticker-management">
                     <div class="form-group">
-                        <label for="finance-ticker">Ticker</label>
+                        <label for="finance-ticker" data-i18n="stockFinance.labels.ticker">Ticker</label>
                         <input type="text" id="finance-ticker" style="text-transform: uppercase;">
                     </div>
                     <div class="form-group">
-                        <label for="finance-date">Reports starting from</label>
+                        <label for="finance-date" data-i18n="stockFinance.labels.reportsFrom">Reports starting from</label>
                         <input type="date" id="finance-date" min="2011-01-01">
                     </div>
                     <div class="form-group">
-                        <label for="finance-timeframe">Timeframe</label>
+                        <label for="finance-timeframe" data-i18n="stockFinance.labels.timeframe">Timeframe</label>
                         <select id="finance-timeframe">
-                            <option value="quarterly">Quarterly</option>
-                            <option value="annual">Annual</option>
-                            <option value="ttm">TTM</option>
+                            <option value="quarterly" data-i18n="stockFinance.labels.timeframes.quarterly">Quarterly</option>
+                            <option value="annual" data-i18n="stockFinance.labels.timeframes.annual">Annual</option>
+                            <option value="ttm" data-i18n="stockFinance.labels.timeframes.ttm">TTM</option>
                         </select>
                     </div>
-                    <button class="btn btn-primary" id="fetch-financials-btn">Get Reports</button>
+                    <button class="btn btn-primary" id="fetch-financials-btn" data-i18n="stockFinance.labels.getReports">Get Reports</button>
                 </div>
 
                 <div class="sub-nav-tabs" id="finance-subtabs">
-                    <button class="sub-nav-tab active" data-fin-subtab="income">Income Statement</button>
-                    <button class="sub-nav-tab" data-fin-subtab="balance">Balance Sheet</button>
-                    <button class="sub-nav-tab" data-fin-subtab="cash">Cash Flow</button>
-                    <button class="sub-nav-tab" data-fin-subtab="stats">Statistics</button>
+                    <button class="sub-nav-tab active" data-fin-subtab="income" data-i18n="stockFinance.tabs.income">Income Statement</button>
+                    <button class="sub-nav-tab" data-fin-subtab="balance" data-i18n="stockFinance.tabs.balance">Balance Sheet</button>
+                    <button class="sub-nav-tab" data-fin-subtab="cash" data-i18n="stockFinance.tabs.cash">Cash Flow</button>
+                    <button class="sub-nav-tab" data-fin-subtab="stats" data-i18n="stockFinance.tabs.stats">Statistics</button>
                 </div>
 
                 <div id="finance-zero-info" class="zero-info" style="display:none;"></div>

--- a/app/js/calculator.js
+++ b/app/js/calculator.js
@@ -144,13 +144,13 @@ const Calculator = (function() {
             tbody.innerHTML = '';
             let value = initial;
             const row0 = document.createElement('tr');
-            row0.innerHTML = `<td>Start</td><td>-</td><td>${formatCurrency(value)}</td>`;
+            row0.innerHTML = `<td>${I18n.t('calculators.investment.table.start')}</td><td>-</td><td>${formatCurrency(value)}</td>`;
             tbody.appendChild(row0);
             for (let i = 1; i <= years; i++) {
                 const newValue = value * (1 + annualRateDecimal);
                 const growth = newValue - value;
                 const tr = document.createElement('tr');
-                tr.innerHTML = `<td>Year ${i}</td><td>${formatCurrency(growth)}</td><td>${formatCurrency(newValue)}</td>`;
+                tr.innerHTML = `<td>${I18n.t('calculators.investment.table.year')} ${i}</td><td>${formatCurrency(growth)}</td><td>${formatCurrency(newValue)}</td>`;
                 tbody.appendChild(tr);
                 value = newValue;
             }

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -95,6 +95,102 @@ const I18n = (function() {
                     "investment": "Investment Calculator",
                     "cagr": "CAGR Calculator",
                     "fairValue": "Fair Value Calculator"
+                },
+                "loan": {
+                    "labels": {
+                        "principal": "Principal Amount",
+                        "rate": "Annual Interest Rate (%)",
+                        "term": "Loan Term (Years)"
+                    },
+                    "results": {
+                        "monthlyPayment": "Monthly Payment:",
+                        "totalInterest": "Total Interest:",
+                        "totalAmount": "Total Amount:"
+                    }
+                },
+                "investment": {
+                    "labels": {
+                        "initial": "Initial Investment",
+                        "rate": "Annual Return Rate (%)",
+                        "years": "Investment Period (Years)"
+                    },
+                    "results": {
+                        "totalReturn": "Total Return (Interest):",
+                        "finalValue": "Final Value:"
+                    },
+                    "table": {
+                        "year": "Year",
+                        "growth": "Growth",
+                        "value": "Value",
+                        "start": "Start"
+                    }
+                },
+                "cagr": {
+                    "labels": {
+                        "beginning": "Beginning Value ($)",
+                        "ending": "Ending Value ($)",
+                        "years": "Number of Years"
+                    },
+                    "results": {
+                        "totalReturn": "Total Return:",
+                        "cagr": "Compound Annual Growth Rate (CAGR):"
+                    }
+                },
+                "fairValue": {
+                    "tabs": {
+                        "dcf": "DCF Analysis",
+                        "pe": "P/E Ratio Analysis",
+                        "intrinsic": "Intrinsic Value"
+                    },
+                    "dcf": {
+                        "title": "Discounted Cash Flow (DCF) Analysis",
+                        "labels": {
+                            "currentFCF": "Current Annual Free Cash Flow",
+                            "growthRate": "Growth Rate (%)",
+                            "terminalRate": "Terminal Growth Rate (%)",
+                            "discountRate": "Discount Rate (WACC) (%)",
+                            "years": "Projection Years",
+                            "shares": "Shares Outstanding (M)"
+                        },
+                        "results": {
+                            "enterpriseValue": "Enterprise Value:",
+                            "pvCashflows": "Present Value of Cash Flows:",
+                            "terminalValue": "Terminal Value:",
+                            "perShare": "Intrinsic Value Per Share:"
+                        }
+                    },
+                    "pe": {
+                        "title": "P/E Ratio Analysis",
+                        "labels": {
+                            "currentPrice": "Current Stock Price ($)",
+                            "eps": "Earnings Per Share (EPS) ($)",
+                            "industryPE": "Industry Average P/E",
+                            "growthRate": "Expected EPS Growth Rate (%)"
+                        },
+                        "results": {
+                            "currentPE": "Current P/E Ratio:",
+                            "fairValue": "Fair Value (Industry P/E):",
+                            "pegRatio": "PEG Ratio:",
+                            "valuation": "Valuation Status:"
+                        }
+                    },
+                    "intrinsic": {
+                        "title": "Intrinsic Value Analysis",
+                        "labels": {
+                            "bookValue": "Book Value Per Share ($)",
+                            "roe": "Return on Equity (ROE) (%)",
+                            "dividendYield": "Dividend Yield (%)",
+                            "requiredReturn": "Required Rate of Return (%)",
+                            "growthRate": "Sustainable Growth Rate (%)",
+                            "eps": "Current EPS ($)"
+                        },
+                        "results": {
+                            "graham": "Graham Number:",
+                            "ddm": "Dividend Discount Model:",
+                            "bookMultiple": "Book Value Multiple:",
+                            "average": "Average Intrinsic Value:"
+                        }
+                    }
                 }
             },
             "stockTracker": {
@@ -103,7 +199,8 @@ const I18n = (function() {
                     "edit": "Edit",
                     "getLastPrice": "Get The Last Price",
                     "addTicker": "Add Ticker",
-                    "generateTable": "Generate Table"
+                    "generateTable": "Generate Table",
+                    "done": "Done"
                 },
                 "labels": {
                     "addStockTicker": "Add Stock Ticker",
@@ -283,7 +380,105 @@ const I18n = (function() {
                     "investment": "Kalkulator investimesh",
                     "cagr": "Kalkulator CAGR",
                     "fairValue": "Kalkulator i vlerës së drejtë"
+                },
+
+                "loan": {
+                    "labels": {
+                        "principal": "Shuma e kredisë",
+                        "rate": "Norma vjetore e interesit (%)",
+                        "term": "Afati i huasë (Vite)",
+                    },
+                    "results": {
+                        "monthlyPayment": "Pagesa mujore:",
+                        "totalInterest": "Interesi total:",
+                        "totalAmount": "Shuma totale:",
+                    }
+                },
+                "investment": {
+                    "labels": {
+                        "initial": "Investimi fillestar",
+                        "rate": "Norma e kthimit vjetor (%)",
+                        "years": "Periudha e investimit (Vite)",
+                    },
+                    "results": {
+                        "totalReturn": "Kthimi total (Interesi):",
+                        "finalValue": "Vlera përfundimtare:",
+                    },
+                    "table": {
+                        "year": "Vit",
+                        "growth": "Rritje",
+                        "value": "Vlera",
+                        "start": "Fillimi",
+                    }
+                },
+                "cagr": {
+                    "labels": {
+                        "beginning": "Vlera fillestare ($)",
+                        "ending": "Vlera përfundimtare ($)",
+                        "years": "Numri i viteve",
+                    },
+                    "results": {
+                        "totalReturn": "Kthimi total:",
+                        "cagr": "Norma vjetore e rritjes së përbërë (CAGR):",
+                    }
+                },
+                "fairValue": {
+                    "tabs": {
+                        "dcf": "Analiza DCF",
+                        "pe": "Analiza e raportit P/E",
+                        "intrinsic": "Vlera e brendshme",
+                    },
+                    "dcf": {
+                        "title": "Analiza e fluksit të parasë së zbritur (DCF)",
+                        "labels": {
+                            "currentFCF": "Fluksi i lirë i parave vjetor aktual",
+                            "growthRate": "Norma e rritjes (%)",
+                            "terminalRate": "Norma terminale e rritjes (%)",
+                            "discountRate": "Norma e zbritjes (WACC) (%)",
+                            "years": "Vitet e projeksionit",
+                            "shares": "Aksionet në qarkullim (M)",
+                        },
+                        "results": {
+                            "enterpriseValue": "Vlera e ndërmarrjes:",
+                            "pvCashflows": "Vlera e tashme e flukseve të parasë:",
+                            "terminalValue": "Vlera terminale:",
+                            "perShare": "Vlera e brendshme për aksion:",
+                        }
+                    },
+                    "pe": {
+                        "title": "Analiza e raportit P/E",
+                        "labels": {
+                            "currentPrice": "Çmimi aktual i aksionit ($)",
+                            "eps": "Fitimi për aksion (EPS) ($)",
+                            "industryPE": "P/E mesatare e industrisë",
+                            "growthRate": "Norma e pritshme e rritjes së EPS (%)",
+                        },
+                        "results": {
+                            "currentPE": "Raporti aktual P/E:",
+                            "fairValue": "Vlera e drejtë (P/E i industrisë):",
+                            "pegRatio": "Raporti PEG:",
+                            "valuation": "Statusi i vlerësimit:",
+                        }
+                    },
+                    "intrinsic": {
+                        "title": "Analiza e vlerës së brendshme",
+                        "labels": {
+                            "bookValue": "Vlera kontabël për aksion ($)",
+                            "roe": "Kthimi mbi kapitalin (ROE) (%)",
+                            "dividendYield": "Rendimenti i dividendës (%)",
+                            "requiredReturn": "Norma e kërkuar e kthimit (%)",
+                            "growthRate": "Norma e qëndrueshme e rritjes (%)",
+                            "eps": "EPS aktual ($)",
+                        },
+                        "results": {
+                            "graham": "Numri i Graham:",
+                            "ddm": "Modeli i zbritjes së dividendëve:",
+                            "bookMultiple": "Shumëzues i vlerës kontabël:",
+                            "average": "Vlera mesatare e brendshme:",
+                        }
+                    }
                 }
+
             },
             "stockTracker": {
                 "title": "Gjurmues i performancës së aksioneve",
@@ -291,7 +486,8 @@ const I18n = (function() {
                     "edit": "Redakto",
                     "getLastPrice": "Merr çmimin e fundit",
                     "addTicker": "Shto Ticker",
-                    "generateTable": "Gjenero Tabelën"
+                    "generateTable": "Gjenero Tabelën",
+                    "done": "Kryer",
                 },
                 "labels": {
                     "addStockTicker": "Shto Ticker Aksionesh",
@@ -471,7 +667,105 @@ const I18n = (function() {
                     "investment": "Calculateur d'investissement",
                     "cagr": "Calculateur de TCAC",
                     "fairValue": "Calculateur de juste valeur"
+                },
+
+                "loan": {
+                    "labels": {
+                        "principal": "Montant du capital",
+                        "rate": "Taux d'intérêt annuel (%)",
+                        "term": "Durée du prêt (années)",
+                    },
+                    "results": {
+                        "monthlyPayment": "Paiement mensuel:",
+                        "totalInterest": "Intérêt total:",
+                        "totalAmount": "Montant total:",
+                    }
+                },
+                "investment": {
+                    "labels": {
+                        "initial": "Investissement initial",
+                        "rate": "Taux de rendement annuel (%)",
+                        "years": "Période d'investissement (années)",
+                    },
+                    "results": {
+                        "totalReturn": "Rendement total (Intérêt):",
+                        "finalValue": "Valeur finale:",
+                    },
+                    "table": {
+                        "year": "Année",
+                        "growth": "Croissance",
+                        "value": "Valeur",
+                        "start": "Début",
+                    }
+                },
+                "cagr": {
+                    "labels": {
+                        "beginning": "Valeur initiale ($)",
+                        "ending": "Valeur finale ($)",
+                        "years": "Nombre d'années",
+                    },
+                    "results": {
+                        "totalReturn": "Rendement total:",
+                        "cagr": "Taux de croissance annuel composé (TCAC):",
+                    }
+                },
+                "fairValue": {
+                    "tabs": {
+                        "dcf": "Analyse DCF",
+                        "pe": "Analyse du ratio P/E",
+                        "intrinsic": "Valeur intrinsèque",
+                    },
+                    "dcf": {
+                        "title": "Analyse des flux de trésorerie actualisés (DCF)",
+                        "labels": {
+                            "currentFCF": "Flux de trésorerie disponible annuel actuel",
+                            "growthRate": "Taux de croissance (%)",
+                            "terminalRate": "Taux de croissance terminal (%)",
+                            "discountRate": "Taux d'actualisation (WACC) (%)",
+                            "years": "Années de projection",
+                            "shares": "Actions en circulation (M)",
+                        },
+                        "results": {
+                            "enterpriseValue": "Valeur d'entreprise:",
+                            "pvCashflows": "Valeur actuelle des flux de trésorerie:",
+                            "terminalValue": "Valeur terminale:",
+                            "perShare": "Valeur intrinsèque par action:",
+                        }
+                    },
+                    "pe": {
+                        "title": "Analyse du ratio P/E",
+                        "labels": {
+                            "currentPrice": "Prix actuel de l'action ($)",
+                            "eps": "Bénéfice par action (BPA) ($)",
+                            "industryPE": "P/E moyen de l'industrie",
+                            "growthRate": "Taux de croissance prévu du BPA (%)",
+                        },
+                        "results": {
+                            "currentPE": "Ratio P/E actuel:",
+                            "fairValue": "Juste valeur (P/E de l'industrie):",
+                            "pegRatio": "Ratio PEG:",
+                            "valuation": "Statut de l'évaluation:",
+                        }
+                    },
+                    "intrinsic": {
+                        "title": "Analyse de la valeur intrinsèque",
+                        "labels": {
+                            "bookValue": "Valeur comptable par action ($)",
+                            "roe": "Rendement des capitaux propres (ROE) (%)",
+                            "dividendYield": "Rendement du dividende (%)",
+                            "requiredReturn": "Taux de rendement requis (%)",
+                            "growthRate": "Taux de croissance durable (%)",
+                            "eps": "BPA actuel ($)",
+                        },
+                        "results": {
+                            "graham": "Nombre de Graham:",
+                            "ddm": "Modèle d'actualisation des dividendes:",
+                            "bookMultiple": "Multiple de la valeur comptable:",
+                            "average": "Valeur intrinsèque moyenne:",
+                        }
+                    }
                 }
+
             },
             "stockTracker": {
                 "title": "Suivi de performance des actions",
@@ -479,7 +773,8 @@ const I18n = (function() {
                     "edit": "Modifier",
                     "getLastPrice": "Obtenir le dernier prix",
                     "addTicker": "Ajouter le ticker",
-                    "generateTable": "Générer une table"
+                    "generateTable": "Générer une table",
+                    "done": "Terminé",
                 },
                 "labels": {
                     "addStockTicker": "Ajouter un ticker d'actions",
@@ -659,7 +954,105 @@ const I18n = (function() {
                     "investment": "Investmentrechner",
                     "cagr": "CAGR-Rechner",
                     "fairValue": "Fair-Value-Rechner"
+                },
+
+                "loan": {
+                    "labels": {
+                        "principal": "Darlehensbetrag",
+                        "rate": "Jährlicher Zinssatz (%)",
+                        "term": "Darlehenslaufzeit (Jahre)",
+                    },
+                    "results": {
+                        "monthlyPayment": "Monatliche Zahlung:",
+                        "totalInterest": "Gesamtzins:",
+                        "totalAmount": "Gesamtbetrag:",
+                    }
+                },
+                "investment": {
+                    "labels": {
+                        "initial": "Anfangsinvestition",
+                        "rate": "Jährliche Rendite (%)",
+                        "years": "Anlagezeitraum (Jahre)",
+                    },
+                    "results": {
+                        "totalReturn": "Gesamtrendite (Zinsen):",
+                        "finalValue": "Endwert:",
+                    },
+                    "table": {
+                        "year": "Jahr",
+                        "growth": "Wachstum",
+                        "value": "Wert",
+                        "start": "Start",
+                    }
+                },
+                "cagr": {
+                    "labels": {
+                        "beginning": "Anfangswert ($)",
+                        "ending": "Endwert ($)",
+                        "years": "Anzahl der Jahre",
+                    },
+                    "results": {
+                        "totalReturn": "Gesamtrendite:",
+                        "cagr": "Jährliche Wachstumsrate (CAGR):",
+                    }
+                },
+                "fairValue": {
+                    "tabs": {
+                        "dcf": "DCF-Analyse",
+                        "pe": "P/E-Verhältnis-Analyse",
+                        "intrinsic": "Innerer Wert",
+                    },
+                    "dcf": {
+                        "title": "Discounted Cashflow (DCF)-Analyse",
+                        "labels": {
+                            "currentFCF": "Aktueller jährlicher Free Cashflow",
+                            "growthRate": "Wachstumsrate (%)",
+                            "terminalRate": "Terminale Wachstumsrate (%)",
+                            "discountRate": "Abzinsungssatz (WACC) (%)",
+                            "years": "Prognosejahre",
+                            "shares": "Ausstehende Aktien (M)",
+                        },
+                        "results": {
+                            "enterpriseValue": "Unternehmenswert:",
+                            "pvCashflows": "Barwert der Cashflows:",
+                            "terminalValue": "Terminalwert:",
+                            "perShare": "Innerer Wert je Aktie:",
+                        }
+                    },
+                    "pe": {
+                        "title": "P/E-Verhältnis-Analyse",
+                        "labels": {
+                            "currentPrice": "Aktueller Aktienkurs ($)",
+                            "eps": "Gewinn je Aktie (EPS) ($)",
+                            "industryPE": "Branchendurchschnitt P/E",
+                            "growthRate": "Erwartete EPS-Wachstumsrate (%)",
+                        },
+                        "results": {
+                            "currentPE": "Aktuelles P/E-Verhältnis:",
+                            "fairValue": "Fairer Wert (Branchen-P/E):",
+                            "pegRatio": "PEG-Verhältnis:",
+                            "valuation": "Bewertungsstatus:",
+                        }
+                    },
+                    "intrinsic": {
+                        "title": "Analyse des inneren Wertes",
+                        "labels": {
+                            "bookValue": "Buchwert je Aktie ($)",
+                            "roe": "Eigenkapitalrendite (ROE) (%)",
+                            "dividendYield": "Dividendenrendite (%)",
+                            "requiredReturn": "Erforderliche Rendite (%)",
+                            "growthRate": "Nachhaltige Wachstumsrate (%)",
+                            "eps": "Aktuelles EPS ($)",
+                        },
+                        "results": {
+                            "graham": "Graham-Zahl:",
+                            "ddm": "Dividenden-Discount-Modell:",
+                            "bookMultiple": "Buchwert-Multiple:",
+                            "average": "Durchschnittlicher innerer Wert:",
+                        }
+                    }
                 }
+
             },
             "stockTracker": {
                 "title": "Aktien-Performance-Tracker",
@@ -667,7 +1060,8 @@ const I18n = (function() {
                     "edit": "Bearbeiten",
                     "getLastPrice": "Letzten Preis abrufen",
                     "addTicker": "Ticker hinzufügen",
-                    "generateTable": "Tabelle erzeugen"
+                    "generateTable": "Tabelle erzeugen",
+                    "done": "Fertig",
                 },
                 "labels": {
                     "addStockTicker": "Aktien-Ticker hinzufügen",
@@ -847,7 +1241,105 @@ const I18n = (function() {
                     "investment": "Calculadora de inversiones",
                     "cagr": "Calculadora CAGR",
                     "fairValue": "Calculadora de valor razonable"
+                },
+
+                "loan": {
+                    "labels": {
+                        "principal": "Monto del préstamo",
+                        "rate": "Tasa de interés anual (%)",
+                        "term": "Plazo del préstamo (años)",
+                    },
+                    "results": {
+                        "monthlyPayment": "Pago mensual:",
+                        "totalInterest": "Interés total:",
+                        "totalAmount": "Monto total:",
+                    }
+                },
+                "investment": {
+                    "labels": {
+                        "initial": "Inversión inicial",
+                        "rate": "Tasa de retorno anual (%)",
+                        "years": "Periodo de inversión (años)",
+                    },
+                    "results": {
+                        "totalReturn": "Retorno total (interés):",
+                        "finalValue": "Valor final:",
+                    },
+                    "table": {
+                        "year": "Año",
+                        "growth": "Crecimiento",
+                        "value": "Valor",
+                        "start": "Inicio",
+                    }
+                },
+                "cagr": {
+                    "labels": {
+                        "beginning": "Valor inicial ($)",
+                        "ending": "Valor final ($)",
+                        "years": "Número de años",
+                    },
+                    "results": {
+                        "totalReturn": "Retorno total:",
+                        "cagr": "Tasa de crecimiento anual compuesta (CAGR):",
+                    }
+                },
+                "fairValue": {
+                    "tabs": {
+                        "dcf": "Análisis DCF",
+                        "pe": "Análisis del ratio P/E",
+                        "intrinsic": "Valor intrínseco",
+                    },
+                    "dcf": {
+                        "title": "Análisis de flujo de caja descontado (DCF)",
+                        "labels": {
+                            "currentFCF": "Flujo de caja libre anual actual",
+                            "growthRate": "Tasa de crecimiento (%)",
+                            "terminalRate": "Tasa de crecimiento terminal (%)",
+                            "discountRate": "Tasa de descuento (WACC) (%)",
+                            "years": "Años de proyección",
+                            "shares": "Acciones en circulación (M)",
+                        },
+                        "results": {
+                            "enterpriseValue": "Valor empresarial:",
+                            "pvCashflows": "Valor presente de los flujos de caja:",
+                            "terminalValue": "Valor terminal:",
+                            "perShare": "Valor intrínseco por acción:",
+                        }
+                    },
+                    "pe": {
+                        "title": "Análisis del ratio P/E",
+                        "labels": {
+                            "currentPrice": "Precio actual de la acción ($)",
+                            "eps": "Ganancias por acción (EPS) ($)",
+                            "industryPE": "P/E promedio de la industria",
+                            "growthRate": "Tasa de crecimiento esperada del EPS (%)",
+                        },
+                        "results": {
+                            "currentPE": "Ratio P/E actual:",
+                            "fairValue": "Valor justo (P/E de la industria):",
+                            "pegRatio": "Ratio PEG:",
+                            "valuation": "Estado de valoración:",
+                        }
+                    },
+                    "intrinsic": {
+                        "title": "Análisis del valor intrínseco",
+                        "labels": {
+                            "bookValue": "Valor en libros por acción ($)",
+                            "roe": "Retorno sobre el patrimonio (ROE) (%)",
+                            "dividendYield": "Rendimiento de dividendos (%)",
+                            "requiredReturn": "Tasa de retorno requerida (%)",
+                            "growthRate": "Tasa de crecimiento sostenible (%)",
+                            "eps": "EPS actual ($)",
+                        },
+                        "results": {
+                            "graham": "Número de Graham:",
+                            "ddm": "Modelo de descuento de dividendos:",
+                            "bookMultiple": "Múltiplo del valor en libros:",
+                            "average": "Valor intrínseco promedio:",
+                        }
+                    }
                 }
+
             },
             "stockTracker": {
                 "title": "Rastreador de rendimiento de acciones",
@@ -855,7 +1347,8 @@ const I18n = (function() {
                     "edit": "Editar",
                     "getLastPrice": "Obtener el último precio",
                     "addTicker": "Agregar ticker",
-                    "generateTable": "Generar tabla"
+                    "generateTable": "Generar tabla",
+                    "done": "Listo",
                 },
                 "labels": {
                     "addStockTicker": "Agregar ticker de acciones",
@@ -1035,7 +1528,105 @@ const I18n = (function() {
                     "investment": "Calcolatore di investimento",
                     "cagr": "Calcolatore CAGR",
                     "fairValue": "Calcolatore del valore equo"
+                },
+
+                "loan": {
+                    "labels": {
+                        "principal": "Importo del prestito",
+                        "rate": "Tasso di interesse annuale (%)",
+                        "term": "Durata del prestito (anni)",
+                    },
+                    "results": {
+                        "monthlyPayment": "Rata mensile:",
+                        "totalInterest": "Interessi totali:",
+                        "totalAmount": "Importo totale:",
+                    }
+                },
+                "investment": {
+                    "labels": {
+                        "initial": "Investimento iniziale",
+                        "rate": "Tasso di rendimento annuale (%)",
+                        "years": "Periodo di investimento (anni)",
+                    },
+                    "results": {
+                        "totalReturn": "Rendimento totale (interessi):",
+                        "finalValue": "Valore finale:",
+                    },
+                    "table": {
+                        "year": "Anno",
+                        "growth": "Crescita",
+                        "value": "Valore",
+                        "start": "Inizio",
+                    }
+                },
+                "cagr": {
+                    "labels": {
+                        "beginning": "Valore iniziale ($)",
+                        "ending": "Valore finale ($)",
+                        "years": "Numero di anni",
+                    },
+                    "results": {
+                        "totalReturn": "Rendimento totale:",
+                        "cagr": "Tasso di crescita annuale composto (CAGR):",
+                    }
+                },
+                "fairValue": {
+                    "tabs": {
+                        "dcf": "Analisi DCF",
+                        "pe": "Analisi del rapporto P/E",
+                        "intrinsic": "Valore intrinseco",
+                    },
+                    "dcf": {
+                        "title": "Analisi del flusso di cassa scontato (DCF)",
+                        "labels": {
+                            "currentFCF": "Flusso di cassa libero annuale attuale",
+                            "growthRate": "Tasso di crescita (%)",
+                            "terminalRate": "Tasso di crescita terminale (%)",
+                            "discountRate": "Tasso di sconto (WACC) (%)",
+                            "years": "Anni di previsione",
+                            "shares": "Azioni in circolazione (M)",
+                        },
+                        "results": {
+                            "enterpriseValue": "Valore d'impresa:",
+                            "pvCashflows": "Valore attuale dei flussi di cassa:",
+                            "terminalValue": "Valore terminale:",
+                            "perShare": "Valore intrinseco per azione:",
+                        }
+                    },
+                    "pe": {
+                        "title": "Analisi del rapporto P/E",
+                        "labels": {
+                            "currentPrice": "Prezzo attuale dell'azione ($)",
+                            "eps": "Utile per azione (EPS) ($)",
+                            "industryPE": "P/E medio del settore",
+                            "growthRate": "Tasso di crescita previsto dell'EPS (%)",
+                        },
+                        "results": {
+                            "currentPE": "Rapporto P/E attuale:",
+                            "fairValue": "Valore equo (P/E del settore):",
+                            "pegRatio": "Rapporto PEG:",
+                            "valuation": "Stato della valutazione:",
+                        }
+                    },
+                    "intrinsic": {
+                        "title": "Analisi del valore intrinseco",
+                        "labels": {
+                            "bookValue": "Valore contabile per azione ($)",
+                            "roe": "Rendimento del capitale proprio (ROE) (%)",
+                            "dividendYield": "Rendimento da dividendo (%)",
+                            "requiredReturn": "Tasso di rendimento richiesto (%)",
+                            "growthRate": "Tasso di crescita sostenibile (%)",
+                            "eps": "EPS attuale ($)",
+                        },
+                        "results": {
+                            "graham": "Numero di Graham:",
+                            "ddm": "Modello di sconto dei dividendi:",
+                            "bookMultiple": "Multiplo del valore contabile:",
+                            "average": "Valore intrinseco medio:",
+                        }
+                    }
                 }
+
             },
             "stockTracker": {
                 "title": "Tracker delle prestazioni azionarie",
@@ -1043,7 +1634,8 @@ const I18n = (function() {
                     "edit": "Modifica",
                     "getLastPrice": "Ottieni l'ultimo prezzo",
                     "addTicker": "Aggiungi ticker",
-                    "generateTable": "Genera tabella"
+                    "generateTable": "Genera tabella",
+                    "done": "Fatto",
                 },
                 "labels": {
                     "addStockTicker": "Aggiungi ticker azionario",

--- a/app/js/stockFinance.js
+++ b/app/js/stockFinance.js
@@ -94,9 +94,9 @@ const StockFinance = (function() {
     };
 
     const STAT_ROWS = [
-        { key: 'pe', label: 'PE Ratio' },
-        { key: 'grossMargin', label: 'Gross Margin' },
-        { key: 'netMargin', label: 'Net Margin' }
+        { key: 'pe', labelKey: 'stockFinance.stats.peRatio' },
+        { key: 'grossMargin', labelKey: 'stockFinance.stats.grossMargin' },
+        { key: 'netMargin', labelKey: 'stockFinance.stats.netMargin' }
     ];
 
     let reports = [];
@@ -132,7 +132,7 @@ const StockFinance = (function() {
 
     function showZeroInfo() {
         if (!zeroInfoEl) return;
-        zeroInfoEl.textContent = 'Values trimmed by removing 6 trailing zeros ("000,000")';
+        zeroInfoEl.textContent = I18n.t('stockFinance.zeroInfo');
         zeroInfoEl.style.display = 'block';
     }
 
@@ -247,14 +247,14 @@ const StockFinance = (function() {
             } else {
                 reports = [];
                 tableHead.innerHTML = '';
-                tableBody.innerHTML = '<tr><td>No data available</td></tr>';
+            tableBody.innerHTML = `<tr><td>${I18n.t('stockFinance.messages.noData')}</td></tr>`;
                 tableContainer.style.display = 'block';
                 if (zeroInfoEl) zeroInfoEl.style.display = 'none';
             }
         } catch (e) {
             reports = [];
             tableHead.innerHTML = '';
-            tableBody.innerHTML = '<tr><td>Failed to load data</td></tr>';
+            tableBody.innerHTML = `<tr><td>${I18n.t('stockFinance.messages.loadFailed')}</td></tr>`;
             tableContainer.style.display = 'block';
             if (zeroInfoEl) zeroInfoEl.style.display = 'none';
         }
@@ -275,7 +275,7 @@ const StockFinance = (function() {
         tableBody.innerHTML = '';
 
         const headerRow = document.createElement('tr');
-        let headerHtml = '<th>Label</th>';
+        let headerHtml = `<th>${I18n.t('stockFinance.table.label')}</th>`;
         reports.forEach(r => {
             const yr = r.fiscal_year || '';
             const period = r.fiscal_period || '';
@@ -304,7 +304,7 @@ const StockFinance = (function() {
         if (currentSubTab === 'stats') {
             const stats = calculateStats();
             STAT_ROWS.forEach(row => {
-                let rowHtml = `<td>${row.label}</td>`;
+                let rowHtml = `<td>${I18n.t(row.labelKey)}</td>`;
                 stats[row.key].forEach(val => {
                     if (val === null || val === undefined || isNaN(val)) {
                         rowHtml += '<td></td>';

--- a/app/js/stockTracker.js
+++ b/app/js/stockTracker.js
@@ -122,7 +122,7 @@ const StockTracker = (function() {
     function toggleEditMode() {
         editMode = !editMode;
         const btn = document.getElementById('edit-stock-btn');
-        if (btn) btn.textContent = editMode ? 'Done' : 'Edit';
+        if (btn) btn.textContent = editMode ? I18n.t('stockTracker.actions.done') : I18n.t('stockTracker.actions.edit');
         applyEditMode();
     }
 
@@ -162,7 +162,7 @@ const StockTracker = (function() {
 
         // Generate table header
         const headerRow = document.getElementById('table-header');
-        headerRow.innerHTML = '<tr><th>Year</th>' + 
+        headerRow.innerHTML = `<tr><th>${I18n.t('stockTracker.table.year')}</th>` +
             stockData.tickers.map(ticker => `<th>${ticker}</th>`).join('') + '</tr>';
 
         // Generate table body
@@ -219,15 +219,15 @@ const StockTracker = (function() {
         // Add summary rows
         const totalGrowthRow = document.createElement('tr');
         totalGrowthRow.className = 'summary-row';
-        totalGrowthRow.innerHTML = '<td><strong>Total Growth</strong></td>';
-        
+        totalGrowthRow.innerHTML = `<td><strong>${I18n.t('stockTracker.table.totalGrowth')}</strong></td>`;
+
        const cagrRow = document.createElement('tr');
        cagrRow.className = 'summary-row';
-       cagrRow.innerHTML = '<td><strong>CAGR</strong></td>';
+       cagrRow.innerHTML = `<td><strong>${I18n.t('stockTracker.table.cagr')}</strong></td>`;
 
         const chartRow = document.createElement('tr');
         chartRow.className = 'summary-row';
-        chartRow.innerHTML = '<td><strong>Chart</strong></td>';
+        chartRow.innerHTML = `<td><strong>${I18n.t('stockTracker.table.chart')}</strong></td>`;
 
        stockData.tickers.forEach(ticker => {
             const totalCell = document.createElement('td');


### PR DESCRIPTION
## Summary
- Add translation hooks for calculators UI, including titles, tab labels, and calculation fields
- Localize stock performance tracker buttons, labels, table headers, and summary cards
- Localize stock finance performance inputs, tabs, and dynamic table rendering
- Extend non-English locales with calculator terms and stock tracker completion actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897c2418d18832f8d73e67d9d80a12a