### PR TITLE
feat: localize dialog interactions

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -204,9 +204,10 @@ test('Add Portfolio prompt focuses text input when opened', () => {
     </div>`;
   const dom = new JSDOM(html, {url: 'http://localhost'});
   const context = vm.createContext(dom.window);
+  vm.runInContext(i18nCode, context);
   const dm = fs.readFileSync(path.resolve(__dirname, '../app/js/dialogManager.js'), 'utf8');
   vm.runInContext(dm, context);
-  vm.runInContext('DialogManager.prompt("Enter portfolio name:")', context);
+  vm.runInContext('DialogManager.prompt(I18n.t("dialog.enterPortfolioName"))', context);
   expect(dom.window.document.activeElement.id).toBe('dialog-input');
 });
 

--- a/app/index.html
+++ b/app/index.html
@@ -234,18 +234,18 @@
                 <div id="transaction-history-modal" class="modal">
                     <div class="modal-content">
                         <span class="modal-close" id="transaction-history-close">&times;</span>
-                        <h3>Transaction History</h3>
+                        <h3 data-i18n="portfolio.actions.transactionHistory">Transaction History</h3>
                         <div class="table-container" style="max-height: 60vh; overflow-y: auto;">
                             <table class="data-table">
                                 <thead>
                                     <tr>
-                                        <th>Ticker</th>
-                                        <th>Currency</th>
-                                        <th>Name</th>
-                                        <th>Quantity</th>
-                                        <th>Purchase Price</th>
-                                        <th>Last Price</th>
-                                        <th>Purchase Date</th>
+                                        <th data-i18n="portfolio.table.ticker">Ticker</th>
+                                        <th data-i18n="portfolio.table.currency">Currency</th>
+                                        <th data-i18n="portfolio.table.name">Name</th>
+                                        <th data-i18n="portfolio.table.quantity">Quantity</th>
+                                        <th data-i18n="portfolio.table.purchasePrice">Purchase Price</th>
+                                        <th data-i18n="portfolio.table.lastPrice">Last Price</th>
+                                        <th data-i18n="portfolio.table.purchaseDate">Purchase Date</th>
                                     </tr>
                                 </thead>
                                 <tbody id="transaction-history-body"></tbody>
@@ -316,26 +316,26 @@
                 <!-- New Pension Modal -->
                 <div id="new-pension-modal" class="modal">
                     <div class="modal-content">
-                        <h3>New Pension</h3>
+                        <h3 data-i18n="pension.dialogs.new.title">New Pension</h3>
                         <form id="new-pension-form">
                             <div class="form-group">
-                                <label for="pension-name">Name</label>
+                                <label for="pension-name" data-i18n="portfolio.table.name">Name</label>
                                 <input type="text" id="pension-name" required>
                             </div>
                             <div class="form-group">
-                                <label for="pension-type">Type</label>
+                                <label for="pension-type" data-i18n="pension.dialogs.new.type">Type</label>
                                 <select id="pension-type">
-                                    <option value="growth">Growth Only</option>
-                                    <option value="payments">Growth with Payments</option>
+                                    <option value="growth" data-i18n="pension.dialogs.new.options.growth">Growth Only</option>
+                                    <option value="payments" data-i18n="pension.dialogs.new.options.payments">Growth with Payments</option>
                                 </select>
                             </div>
                             <div class="form-group">
-                                <label for="pension-start-value">Starting Value</label>
+                                <label for="pension-start-value" data-i18n="pension.dialogs.new.startingValue">Starting Value</label>
                                 <input type="number" step="0.01" id="pension-start-value" required>
                             </div>
                             <div class="modal-actions">
-                                <button type="button" class="btn btn-secondary" id="cancel-new-pension">Cancel</button>
-                                <button type="submit" class="btn btn-primary">Add</button>
+                                <button type="button" class="btn btn-secondary" id="cancel-new-pension" data-i18n="common.cancel">Cancel</button>
+                                <button type="submit" class="btn btn-primary" data-i18n="common.add">Add</button>
                             </div>
                         </form>
                     </div>
@@ -344,23 +344,23 @@
                 <!-- Pension Entry Modal -->
                 <div id="pension-entry-modal" class="modal">
                     <div class="modal-content">
-                        <h3>Add Entry</h3>
+                        <h3 data-i18n="pension.actions.addEntry">Add Entry</h3>
                         <form id="pension-entry-form">
                             <div class="form-group">
-                                <label for="pension-entry-date">Date</label>
+                                <label for="pension-entry-date" data-i18n="pension.table.date">Date</label>
                                 <input type="date" id="pension-entry-date" required>
                             </div>
                             <div class="form-group">
-                                <label for="pension-entry-value">Current Value</label>
+                                <label for="pension-entry-value" data-i18n="pension.table.currentValue">Current Value</label>
                                 <input type="number" step="0.01" id="pension-entry-value" required>
                             </div>
                             <div class="form-group" id="payment-group">
-                                <label for="pension-entry-payment">Payment</label>
+                                <label for="pension-entry-payment" data-i18n="pension.table.payment">Payment</label>
                                 <input type="number" step="0.01" id="pension-entry-payment">
                             </div>
                             <div class="modal-actions">
-                                <button type="button" class="btn btn-secondary" id="cancel-pension-entry">Cancel</button>
-                                <button type="submit" class="btn btn-primary">Add</button>
+                                <button type="button" class="btn btn-secondary" id="cancel-pension-entry" data-i18n="common.cancel">Cancel</button>
+                                <button type="submit" class="btn btn-primary" data-i18n="common.add">Add</button>
                             </div>
                         </form>
                     </div>
@@ -369,23 +369,23 @@
                 <!-- Edit Pension Entry Modal -->
                 <div id="pension-edit-modal" class="modal">
                     <div class="modal-content">
-                        <h3>Edit Entry</h3>
+                        <h3 data-i18n="pension.dialogs.editEntry.title">Edit Entry</h3>
                         <form id="pension-edit-form">
                             <div class="form-group">
-                                <label for="pension-edit-date">Date</label>
+                                <label for="pension-edit-date" data-i18n="pension.table.date">Date</label>
                                 <input type="date" id="pension-edit-date" required>
                             </div>
                             <div class="form-group">
-                                <label for="pension-edit-value">Current Value</label>
+                                <label for="pension-edit-value" data-i18n="pension.table.currentValue">Current Value</label>
                                 <input type="number" step="0.01" id="pension-edit-value" required>
                             </div>
                             <div class="form-group" id="edit-payment-group">
-                                <label for="pension-edit-payment">Payment</label>
+                                <label for="pension-edit-payment" data-i18n="pension.table.payment">Payment</label>
                                 <input type="number" step="0.01" id="pension-edit-payment">
                             </div>
                             <div class="modal-actions">
-                                <button type="button" class="btn btn-secondary" id="cancel-pension-edit">Cancel</button>
-                                <button type="submit" class="btn btn-primary">Save</button>
+                                <button type="button" class="btn btn-secondary" id="cancel-pension-edit" data-i18n="common.cancel">Cancel</button>
+                                <button type="submit" class="btn btn-primary" data-i18n="common.save">Save</button>
                             </div>
                         </form>
                     </div>
@@ -395,7 +395,7 @@
                 <div id="pension-chart-popup" class="modal">
                     <div class="modal-content">
                         <span class="modal-close" id="pension-chart-close">&times;</span>
-                        <h3>Pension Chart</h3>
+                        <h3 data-i18n="pension.chart.title">Pension Chart</h3>
                         <div class="chart-control-panel">
                             <div class="ticker-select" id="pension-chart-select"></div>
                         </div>
@@ -735,7 +735,7 @@
                 <div id="stock-chart-popup" class="modal">
                     <div class="modal-content">
                         <span class="modal-close" id="chart-popup-close">&times;</span>
-                        <h3 id="chart-popup-title"></h3>
+                        <h3 id="chart-popup-title" data-i18n="stockTracker.chart.title"></h3>
                         <div class="chart-control-panel">
                             <div class="chart-type">
                                 <label><input type="radio" name="chart-type" id="chart-type-price" value="price" checked> <span data-i18n="stockTracker.chart.price">Price</span></label>

--- a/app/js/dialogManager.js
+++ b/app/js/dialogManager.js
@@ -17,12 +17,13 @@ const DialogManager = (function() {
             inputGroup.style.display = 'none';
         }
         cancelBtn.style.display = type === 'alert' ? 'none' : 'inline-flex';
-        cancelBtn.textContent = 'No';
+        cancelBtn.textContent = I18n.t('dialog.no');
 
         if (type === 'alert') {
-            okBtn.textContent = 'Close';
+            okBtn.textContent = I18n.t('dialog.close');
         } else {
-            okBtn.textContent = actionLabel ? `Yes, ${actionLabel}` : 'Yes';
+            const yes = I18n.t('dialog.yes');
+            okBtn.textContent = actionLabel ? `${yes}, ${actionLabel}` : yes;
         }
         modal.style.display = 'flex';
         if (type === 'prompt') inputEl.focus();

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -283,6 +283,23 @@ const I18n = (function() {
                 "importLang": "Import Language",
                 "rtlToggle": "Enable RTL"
             },
+            "dialog": {
+                "yes": "Yes",
+                "no": "No",
+                "close": "Close",
+                "delete": "Delete",
+                "enterPortfolioName": "Enter portfolio name:",
+                "deletePortfolio": "Delete this portfolio?",
+                "tickerNotExist": "Ticker symbol does not exist",
+                "enterValidTicker": "Please enter a valid ticker symbol.",
+                "purchaseDateFuture": "Purchase date cannot be in the future.",
+                "deleteInvestment": "Delete this investment?",
+                "deletePension": "Delete this pension?",
+                "deleteEntry": "Delete this entry?",
+                "deleteAllPension": "Delete all pension data?",
+                "deleteAllPortfolio": "Delete all portfolio data?",
+                "deleteAllStock": "Delete all stock tracker data?"
+            },
             "common": {
                 "format": "Format",
                 "file": "File",
@@ -569,6 +586,23 @@ const I18n = (function() {
                 "exportLang": "Eksporto Gjuhën",
                 "importLang": "Importo Gjuhën",
                 "rtlToggle": "Aktivizo RTL"
+            },
+            "dialog": {
+                "yes": "Po",
+                "no": "Jo",
+                "close": "Mbyll",
+                "delete": "Fshi",
+                "enterPortfolioName": "Shkruani emrin e portofolit:",
+                "deletePortfolio": "Ta fshij këtë portofol?",
+                "tickerNotExist": "Simboli i aksionit nuk ekziston",
+                "enterValidTicker": "Ju lutemi, shkruani një simbol të vlefshëm.",
+                "purchaseDateFuture": "Data e blerjes nuk mund të jetë në të ardhmen.",
+                "deleteInvestment": "Ta fshij këtë investim?",
+                "deletePension": "Ta fshij këtë pension?",
+                "deleteEntry": "Ta fshij këtë shënim?",
+                "deleteAllPension": "Të fshij të gjithë të dhënat e pensionit?",
+                "deleteAllPortfolio": "Të fshij të gjitha të dhënat e portofolit?",
+                "deleteAllStock": "Të fshij të gjitha të dhënat e gjurmuesit të aksioneve?"
             },
             "common": {
                 "format": "Formati",
@@ -857,6 +891,23 @@ const I18n = (function() {
                 "importLang": "Importer la Langue",
                 "rtlToggle": "Activer RTL"
             },
+            "dialog": {
+                "yes": "Oui",
+                "no": "Non",
+                "close": "Fermer",
+                "delete": "Supprimer",
+                "enterPortfolioName": "Entrez le nom du portefeuille :",
+                "deletePortfolio": "Supprimer ce portefeuille ?",
+                "tickerNotExist": "Le symbole boursier n'existe pas",
+                "enterValidTicker": "Veuillez entrer un symbole valide.",
+                "purchaseDateFuture": "La date d'achat ne peut pas être dans le futur.",
+                "deleteInvestment": "Supprimer cet investissement ?",
+                "deletePension": "Supprimer cette pension ?",
+                "deleteEntry": "Supprimer cette entrée ?",
+                "deleteAllPension": "Supprimer toutes les données de retraite ?",
+                "deleteAllPortfolio": "Supprimer toutes les données de portefeuille ?",
+                "deleteAllStock": "Supprimer toutes les données du suivi des actions ?"
+            },
             "common": {
                 "format": "Format",
                 "file": "Fichier",
@@ -1143,6 +1194,23 @@ const I18n = (function() {
                 "exportLang": "Sprache exportieren",
                 "importLang": "Sprache importieren",
                 "rtlToggle": "RTL aktivieren"
+            },
+            "dialog": {
+                "yes": "Ja",
+                "no": "Nein",
+                "close": "Schließen",
+                "delete": "Löschen",
+                "enterPortfolioName": "Portfolionamen eingeben:",
+                "deletePortfolio": "Dieses Portfolio löschen?",
+                "tickerNotExist": "Tickersymbol existiert nicht",
+                "enterValidTicker": "Bitte geben Sie ein gültiges Tickersymbol ein.",
+                "purchaseDateFuture": "Kaufdatum darf nicht in der Zukunft liegen.",
+                "deleteInvestment": "Diese Investition löschen?",
+                "deletePension": "Diese Rente löschen?",
+                "deleteEntry": "Diesen Eintrag löschen?",
+                "deleteAllPension": "Alle Rentendaten löschen?",
+                "deleteAllPortfolio": "Alle Portfoliodaten löschen?",
+                "deleteAllStock": "Alle Daten des Aktien-Trackers löschen?"
             },
             "common": {
                 "format": "Format",
@@ -1431,6 +1499,23 @@ const I18n = (function() {
                 "importLang": "Importar Idioma",
                 "rtlToggle": "Habilitar RTL"
             },
+            "dialog": {
+                "yes": "Sí",
+                "no": "No",
+                "close": "Cerrar",
+                "delete": "Eliminar",
+                "enterPortfolioName": "Ingrese el nombre del portafolio:",
+                "deletePortfolio": "¿Eliminar este portafolio?",
+                "tickerNotExist": "El símbolo de cotización no existe",
+                "enterValidTicker": "Por favor, ingrese un símbolo válido.",
+                "purchaseDateFuture": "La fecha de compra no puede estar en el futuro.",
+                "deleteInvestment": "¿Eliminar esta inversión?",
+                "deletePension": "¿Eliminar esta pensión?",
+                "deleteEntry": "¿Eliminar esta entrada?",
+                "deleteAllPension": "¿Eliminar todos los datos de pensión?",
+                "deleteAllPortfolio": "¿Eliminar todos los datos de portafolio?",
+                "deleteAllStock": "¿Eliminar todos los datos del rastreador de acciones?"
+            },
             "common": {
                 "format": "Formato",
                 "file": "Archivo",
@@ -1717,6 +1802,23 @@ const I18n = (function() {
                 "exportLang": "Esporta Lingua",
                 "importLang": "Importa Lingua",
                 "rtlToggle": "Abilita RTL"
+            },
+            "dialog": {
+                "yes": "Sì",
+                "no": "No",
+                "close": "Chiudi",
+                "delete": "Elimina",
+                "enterPortfolioName": "Inserisci il nome del portafoglio:",
+                "deletePortfolio": "Eliminare questo portafoglio?",
+                "tickerNotExist": "Il simbolo ticker non esiste",
+                "enterValidTicker": "Per favore inserisci un simbolo valido.",
+                "purchaseDateFuture": "La data di acquisto non può essere nel futuro.",
+                "deleteInvestment": "Eliminare questo investimento?",
+                "deletePension": "Eliminare questa pensione?",
+                "deleteEntry": "Eliminare questa voce?",
+                "deleteAllPension": "Eliminare tutti i dati della pensione?",
+                "deleteAllPortfolio": "Eliminare tutti i dati del portafoglio?",
+                "deleteAllStock": "Eliminare tutti i dati del tracker azionario?"
             },
             "common": {
                 "format": "Formato",

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -42,6 +42,7 @@ const I18n = (function() {
                 "principal": "Principal",
                 "quantity": "Quantity",
                 "lastPrice": "Last Price",
+                "purchaseDate": "Purchase Date",
                 "value": "Value",
                 "pl": "P&L",
                 "plPct": "P&L %",
@@ -86,6 +87,23 @@ const I18n = (function() {
                     "worstMonth": "Worst Month",
                     "bestYear": "Best Year",
                     "worstYear": "Worst Year"
+                },
+                "dialogs": {
+                    "new": {
+                        "title": "New Pension",
+                        "type": "Type",
+                        "startingValue": "Starting Value",
+                        "options": {
+                            "growth": "Growth Only",
+                            "payments": "Growth with Payments"
+                        }
+                    },
+                    "editEntry": {
+                        "title": "Edit Entry"
+                    }
+                },
+                "chart": {
+                    "title": "Pension Chart"
                 }
             },
             "calculators": {
@@ -219,6 +237,7 @@ const I18n = (function() {
                     "consistent": "Most Consistent"
                 },
                 "chart": {
+                    "title": "Stock Chart",
                     "price": "Price",
                     "growth": "Growth"
                 }
@@ -306,6 +325,8 @@ const I18n = (function() {
                 "cancel": "Cancel",
                 "import": "Import",
                 "export": "Export",
+                "add": "Add",
+                "save": "Save",
                 "summary": "Summary"
             }
         },
@@ -344,6 +365,7 @@ const I18n = (function() {
                 "principal": "Kapitali",
                 "quantity": "Sasia",
                 "lastPrice": "Çmimi i Fundit",
+                "purchaseDate": "Data e Blerjes",
                 "value": "Vlera",
                 "pl": "Fitimi/Humbja",
                 "plPct": "Fitimi/Humbja %",
@@ -388,6 +410,23 @@ const I18n = (function() {
                     "worstMonth": "Muaji Më i Keq",
                     "bestYear": "Viti Më i Mirë",
                     "worstYear": "Viti Më i Keq"
+                },
+                "dialogs": {
+                    "new": {
+                        "title": "Pension i Ri",
+                        "type": "Lloji",
+                        "startingValue": "Vlera Fillestare",
+                        "options": {
+                            "growth": "Vetëm Rritje",
+                            "payments": "Rritje me Pagesa"
+                        }
+                    },
+                    "editEntry": {
+                        "title": "Ndrysho Shënimin"
+                    }
+                },
+                "chart": {
+                    "title": "Grafiku i Pensionit"
                 }
             },
             "calculators": {
@@ -523,6 +562,7 @@ const I18n = (function() {
                     "consistent": "Më i qëndrueshëm"
                 },
                 "chart": {
+                    "title": "Grafiku i Aksioneve",
                     "price": "Çmim",
                     "growth": "Rritje"
                 }
@@ -610,6 +650,8 @@ const I18n = (function() {
                 "cancel": "Anulo",
                 "import": "Importo",
                 "export": "Eksporto",
+                "add": "Shto",
+                "save": "Ruaj",
                 "summary": "Përmbledhje"
             }
         },
@@ -648,6 +690,7 @@ const I18n = (function() {
                 "principal": "Capital",
                 "quantity": "Quantité",
                 "lastPrice": "Dernier Prix",
+                "purchaseDate": "Date d'Achat",
                 "value": "Valeur",
                 "pl": "P&L",
                 "plPct": "P&L %",
@@ -692,6 +735,23 @@ const I18n = (function() {
                     "worstMonth": "Pire Mois",
                     "bestYear": "Meilleure Année",
                     "worstYear": "Pire Année"
+                },
+                "dialogs": {
+                    "new": {
+                        "title": "Nouvelle Pension",
+                        "type": "Type",
+                        "startingValue": "Valeur Initiale",
+                        "options": {
+                            "growth": "Croissance seule",
+                            "payments": "Croissance avec versements"
+                        }
+                    },
+                    "editEntry": {
+                        "title": "Modifier l'entrée"
+                    }
+                },
+                "chart": {
+                    "title": "Graphique de Pension"
                 }
             },
             "calculators": {
@@ -827,6 +887,7 @@ const I18n = (function() {
                     "consistent": "Le plus cohérent"
                 },
                 "chart": {
+                    "title": "Graphique Boursier",
                     "price": "Prix",
                     "growth": "Croissance"
                 }
@@ -914,6 +975,8 @@ const I18n = (function() {
                 "cancel": "Annuler",
                 "import": "Importer",
                 "export": "Exporter",
+                "add": "Ajouter",
+                "save": "Enregistrer",
                 "summary": "Résumé"
             }
         },
@@ -952,6 +1015,7 @@ const I18n = (function() {
                 "principal": "Kapital",
                 "quantity": "Menge",
                 "lastPrice": "Letzter Preis",
+                "purchaseDate": "Kaufdatum",
                 "value": "Wert",
                 "pl": "Gewinn/Verlust",
                 "plPct": "Gewinn/Verlust %",
@@ -996,6 +1060,23 @@ const I18n = (function() {
                     "worstMonth": "Schlechtester Monat",
                     "bestYear": "Bestes Jahr",
                     "worstYear": "Schlechtestes Jahr"
+                },
+                "dialogs": {
+                    "new": {
+                        "title": "Neue Rente",
+                        "type": "Typ",
+                        "startingValue": "Startwert",
+                        "options": {
+                            "growth": "Nur Wachstum",
+                            "payments": "Wachstum mit Einzahlungen"
+                        }
+                    },
+                    "editEntry": {
+                        "title": "Eintrag bearbeiten"
+                    }
+                },
+                "chart": {
+                    "title": "Rentendiagramm"
                 }
             },
             "calculators": {
@@ -1131,6 +1212,7 @@ const I18n = (function() {
                     "consistent": "Am beständigsten"
                 },
                 "chart": {
+                    "title": "Aktienchart",
                     "price": "Preis",
                     "growth": "Wachstum"
                 }
@@ -1218,6 +1300,8 @@ const I18n = (function() {
                 "cancel": "Abbrechen",
                 "import": "Importieren",
                 "export": "Exportieren",
+                "add": "Hinzufügen",
+                "save": "Speichern",
                 "summary": "Zusammenfassung"
             }
         },
@@ -1256,6 +1340,7 @@ const I18n = (function() {
                 "principal": "Capital",
                 "quantity": "Cantidad",
                 "lastPrice": "Último Precio",
+                "purchaseDate": "Fecha de Compra",
                 "value": "Valor",
                 "pl": "Ganancia/Pérdida",
                 "plPct": "Ganancia/Pérdida %",
@@ -1300,6 +1385,23 @@ const I18n = (function() {
                     "worstMonth": "Peor Mes",
                     "bestYear": "Mejor Año",
                     "worstYear": "Peor Año"
+                },
+                "dialogs": {
+                    "new": {
+                        "title": "Nueva Pensión",
+                        "type": "Tipo",
+                        "startingValue": "Valor Inicial",
+                        "options": {
+                            "growth": "Solo Crecimiento",
+                            "payments": "Crecimiento con Pagos"
+                        }
+                    },
+                    "editEntry": {
+                        "title": "Editar Entrada"
+                    }
+                },
+                "chart": {
+                    "title": "Gráfico de Pensión"
                 }
             },
             "calculators": {
@@ -1435,6 +1537,7 @@ const I18n = (function() {
                     "consistent": "Más consistente"
                 },
                 "chart": {
+                    "title": "Gráfico de Acciones",
                     "price": "Precio",
                     "growth": "Crecimiento"
                 }
@@ -1522,6 +1625,8 @@ const I18n = (function() {
                 "cancel": "Cancelar",
                 "import": "Importar",
                 "export": "Exportar",
+                "add": "Añadir",
+                "save": "Guardar",
                 "summary": "Resumen"
             }
         },
@@ -1560,6 +1665,7 @@ const I18n = (function() {
                 "principal": "Capitale",
                 "quantity": "Quantità",
                 "lastPrice": "Ultimo Prezzo",
+                "purchaseDate": "Data di Acquisto",
                 "value": "Valore",
                 "pl": "Utile/Perdita",
                 "plPct": "Utile/Perdita %",
@@ -1604,6 +1710,23 @@ const I18n = (function() {
                     "worstMonth": "Mese Peggiore",
                     "bestYear": "Anno Migliore",
                     "worstYear": "Anno Peggiore"
+                },
+                "dialogs": {
+                    "new": {
+                        "title": "Nuova Pensione",
+                        "type": "Tipo",
+                        "startingValue": "Valore Iniziale",
+                        "options": {
+                            "growth": "Solo Crescita",
+                            "payments": "Crescita con Versamenti"
+                        }
+                    },
+                    "editEntry": {
+                        "title": "Modifica Voce"
+                    }
+                },
+                "chart": {
+                    "title": "Grafico Pensione"
                 }
             },
             "calculators": {
@@ -1739,6 +1862,7 @@ const I18n = (function() {
                     "consistent": "Più coerente"
                 },
                 "chart": {
+                    "title": "Grafico Azioni",
                     "price": "Prezzo",
                     "growth": "Crescita"
                 }
@@ -1826,6 +1950,8 @@ const I18n = (function() {
                 "cancel": "Annulla",
                 "import": "Importa",
                 "export": "Esporta",
+                "add": "Aggiungi",
+                "save": "Salva",
                 "summary": "Riepilogo"
             }
         }

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -220,7 +220,7 @@ const PensionManager = (function() {
         if (pensions.length <= 1) return;
         const idx = pensions.findIndex(p => p.id === currentPensionId);
         if (idx !== -1) {
-            const confirmed = await DialogManager.confirm('Delete this pension?', 'Delete');
+            const confirmed = await DialogManager.confirm(I18n.t('dialog.deletePension'), I18n.t('dialog.delete'));
             if (!confirmed) return;
             localStorage.removeItem(getStorageKey(currentPensionId));
             pensions.splice(idx, 1);
@@ -291,7 +291,7 @@ const PensionManager = (function() {
         if (btn.classList.contains('edit-btn')) {
             openEditEntryModal(idx);
         } else if (btn.classList.contains('delete-btn')) {
-            const confirmed = await DialogManager.confirm('Delete this entry?', 'Delete');
+            const confirmed = await DialogManager.confirm(I18n.t('dialog.deleteEntry'), I18n.t('dialog.delete'));
             if (confirmed) {
                 entries.splice(idx, 1);
                 saveEntries();

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -385,7 +385,7 @@ const PortfolioManager = (function() {
     }
 
     async function addPortfolio() {
-        const name = await DialogManager.prompt('Enter portfolio name:', '');
+        const name = await DialogManager.prompt(I18n.t('dialog.enterPortfolioName'), '');
         if (!name) return;
         const id = 'pf' + Date.now();
         portfolios.push({ id, name, show: true });
@@ -397,7 +397,7 @@ const PortfolioManager = (function() {
     async function removePortfolio() {
         if (summaryMode) return;
         if (portfolios.length <= 1) return;
-        const confirmed = await DialogManager.confirm('Delete this portfolio?', 'Delete');
+        const confirmed = await DialogManager.confirm(I18n.t('dialog.deletePortfolio'), I18n.t('dialog.delete'));
         if (!confirmed) return;
         const idx = portfolios.findIndex(p => p.id === currentPortfolioId);
         if (idx !== -1) {
@@ -669,7 +669,7 @@ const PortfolioManager = (function() {
             } else {
                 tickerValid = false;
                 document.getElementById('investment-name').value = '';
-                DialogManager.alert('Ticker symbol does not exist');
+                DialogManager.alert(I18n.t('dialog.tickerNotExist'));
             }
         } catch (e) {
             // If the request fails or times out, allow the ticker without validation
@@ -689,13 +689,13 @@ const PortfolioManager = (function() {
         const lastPrice = parseFloat(document.getElementById('investment-last-price').value) || 0;
         const currency = document.getElementById('investment-currency').value || 'USD';
         if (!tickerValid) {
-            DialogManager.alert('Please enter a valid ticker symbol.');
+            DialogManager.alert(I18n.t('dialog.enterValidTicker'));
             return;
         }
         const today = new Date().toISOString().split('T')[0];
         if (!ticker || quantity <= 0 || purchasePrice <= 0 || lastPrice <= 0) return;
         if (!purchaseDate || purchaseDate > today) {
-            DialogManager.alert('Purchase date cannot be in the future.');
+            DialogManager.alert(I18n.t('dialog.purchaseDateFuture'));
             return;
         }
 
@@ -871,7 +871,7 @@ const PortfolioManager = (function() {
         if (qty <= 0 || purchase <= 0 || last <= 0) return;
         const today = new Date().toISOString().split('T')[0];
         if (!date || date > today) {
-            DialogManager.alert('Purchase date cannot be in the future.');
+            DialogManager.alert(I18n.t('dialog.purchaseDateFuture'));
             return;
         }
 
@@ -897,7 +897,7 @@ const PortfolioManager = (function() {
             openEditModal(idx);
         } else if (btn.classList.contains('delete-btn')) {
             const idx = parseInt(btn.dataset.index, 10);
-            const confirmed = await DialogManager.confirm('Delete this investment?', 'Delete');
+            const confirmed = await DialogManager.confirm(I18n.t('dialog.deleteInvestment'), I18n.t('dialog.delete'));
             if (confirmed) {
                 const removed = investments.splice(idx, 1)[0];
                 if (removed && !investments.some(inv => inv.ticker === removed.ticker)) {

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -328,21 +328,21 @@ const Settings = (function() {
 
         if (delPensionsBtn) {
             delPensionsBtn.addEventListener('click', async () => {
-                const c = await DialogManager.confirm('Delete all pension data?', 'Delete');
+                const c = await DialogManager.confirm(I18n.t('dialog.deleteAllPension'), I18n.t('dialog.delete'));
                 if (c) PensionManager.deleteAllData();
             });
         }
 
         if (delPortfolioBtn) {
             delPortfolioBtn.addEventListener('click', async () => {
-                const c = await DialogManager.confirm('Delete all portfolio data?', 'Delete');
+                const c = await DialogManager.confirm(I18n.t('dialog.deleteAllPortfolio'), I18n.t('dialog.delete'));
                 if (c) PortfolioManager.deleteAllData();
             });
         }
 
         if (delStockBtn) {
             delStockBtn.addEventListener('click', async () => {
-                const c = await DialogManager.confirm('Delete all stock tracker data?', 'Delete');
+                const c = await DialogManager.confirm(I18n.t('dialog.deleteAllStock'), I18n.t('dialog.delete'));
                 if (c) StockTracker.deleteAllData();
             });
         }

--- a/app/js/stockTracker.js
+++ b/app/js/stockTracker.js
@@ -404,7 +404,7 @@ const StockTracker = (function() {
         const modal = document.getElementById("stock-chart-popup");
         const canvas = document.getElementById("chartjs-canvas");
         const titleEl = document.getElementById("chart-popup-title");
-        if (titleEl) titleEl.textContent = "Stock Chart";
+        if (titleEl) titleEl.textContent = I18n.t('stockTracker.chart.title');
 
         const tickerContainer = document.getElementById('chart-ticker-select');
         tickerContainer.innerHTML = '';


### PR DESCRIPTION
## Summary
- add translated dialog strings for all supported languages
- wire DialogManager and modules to use I18n for prompts, alerts, and confirmations
- update tests for localized dialog prompts

## Testing
- `cd /workspace/personal-finance-dashboard/app/js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897cfdb2618832f9a1e42d93a6942e4