### PR TITLE
Localize investment dialogs and portfolio actions

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -131,49 +131,49 @@
                 <div id="investment-modal" class="modal">
                     <div class="modal-content">
                         <span class="modal-close" id="investment-close">&times;</span>
-                        <h3>Add Investment</h3>
+                        <h3 data-i18n="portfolio.dialogs.addInvestment.title">Add Investment</h3>
                         <form id="investment-form">
                             <div class="form-grid">
                                 <div class="form-group">
-                                    <label for="investment-ticker">Ticker</label>
+                                      <label for="investment-ticker" data-i18n="portfolio.table.ticker">Ticker</label>
                                     <input type="text" id="investment-ticker" style="text-transform: uppercase;" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-name">Name</label>
+                                      <label for="investment-name" data-i18n="portfolio.table.name">Name</label>
                                     <input type="text" id="investment-name">
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-quantity">Quantity</label>
+                                      <label for="investment-quantity" data-i18n="portfolio.table.quantity">Quantity</label>
                                     <input type="number" step="0.0001" id="investment-quantity" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-purchase-price">Purchase Price</label>
+                                      <label for="investment-purchase-price" data-i18n="portfolio.table.purchasePrice">Purchase Price</label>
                                     <input type="number" step="0.01" id="investment-purchase-price" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-purchase-date">Purchase Date</label>
+                                      <label for="investment-purchase-date" data-i18n="portfolio.table.purchaseDate">Purchase Date</label>
                                     <input type="date" id="investment-purchase-date" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-last-price">Last Price</label>
+                                      <label for="investment-last-price" data-i18n="portfolio.table.lastPrice">Last Price</label>
                                     <input type="number" step="0.01" id="investment-last-price" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="investment-currency">Currency</label>
+                                      <label for="investment-currency" data-i18n="portfolio.table.currency">Currency</label>
                                     <select id="investment-currency">
                                         <option value="USD">USD</option>
                                         <option value="GBP">GBP</option>
                                     </select>
                                 </div>
                                 <div class="form-group">
-                                    <label>Total Value</label>
+                                      <label data-i18n="portfolio.dialogs.totalValue">Total Value</label>
                                     <span id="investment-total-value">$0.00</span>
                                 </div>
                             </div>
                             <div class="modal-actions">
-                                <button type="button" class="btn btn-secondary" id="save-add-another-btn">Save &amp; Add Another</button>
-                                <button type="button" class="btn btn-secondary" id="cancel-investment-btn">Cancel</button>
-                                <button type="submit" class="btn btn-primary">Add</button>
+                                  <button type="button" class="btn btn-secondary" id="save-add-another-btn" data-i18n="portfolio.dialogs.saveAddAnother">Save &amp; Add Another</button>
+                                  <button type="button" class="btn btn-secondary" id="cancel-investment-btn" data-i18n="common.cancel">Cancel</button>
+                                  <button type="submit" class="btn btn-primary" data-i18n="common.add">Add</button>
                             </div>
                         </form>
                     </div>
@@ -183,48 +183,48 @@
                 <div id="edit-investment-modal" class="modal">
                     <div class="modal-content">
                         <span class="modal-close" id="edit-investment-close">&times;</span>
-                        <h3>Edit Investment</h3>
+                          <h3 data-i18n="portfolio.dialogs.editInvestment.title">Edit Investment</h3>
                         <form id="edit-investment-form">
                             <div class="form-grid">
                                 <div class="form-group">
-                                    <label for="edit-name">Name</label>
+                                      <label for="edit-name" data-i18n="portfolio.table.name">Name</label>
                                     <input type="text" id="edit-name">
                                 </div>
                                 <div class="form-group" id="edit-record-group" style="display:none;">
-                                    <label for="edit-record-select">Select Record</label>
+                                      <label for="edit-record-select" data-i18n="portfolio.dialogs.editInvestment.selectRecord">Select Record</label>
                                     <select id="edit-record-select"></select>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-quantity">Quantity</label>
+                                      <label for="edit-quantity" data-i18n="portfolio.table.quantity">Quantity</label>
                                     <input type="number" step="0.0001" id="edit-quantity" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-purchase-price">Purchase Price</label>
+                                      <label for="edit-purchase-price" data-i18n="portfolio.table.purchasePrice">Purchase Price</label>
                                     <input type="number" step="0.01" id="edit-purchase-price" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-purchase-date">Purchase Date</label>
+                                      <label for="edit-purchase-date" data-i18n="portfolio.table.purchaseDate">Purchase Date</label>
                                     <input type="date" id="edit-purchase-date" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-last-price">Last Price</label>
+                                      <label for="edit-last-price" data-i18n="portfolio.table.lastPrice">Last Price</label>
                                     <input type="number" step="0.01" id="edit-last-price" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="edit-currency">Currency</label>
+                                      <label for="edit-currency" data-i18n="portfolio.table.currency">Currency</label>
                                     <select id="edit-currency">
                                         <option value="USD">USD</option>
                                         <option value="GBP">GBP</option>
                                     </select>
                                 </div>
                                 <div class="form-group">
-                                    <label>Total Value</label>
+                                      <label data-i18n="portfolio.dialogs.totalValue">Total Value</label>
                                     <span id="edit-total-value">$0.00</span>
                                 </div>
                             </div>
                             <div class="modal-actions">
-                                <button type="button" class="btn btn-secondary" id="edit-cancel-btn">Cancel</button>
-                                <button type="submit" class="btn btn-primary">Save</button>
+                                  <button type="button" class="btn btn-secondary" id="edit-cancel-btn" data-i18n="common.cancel">Cancel</button>
+                                  <button type="submit" class="btn btn-primary" data-i18n="common.save">Save</button>
                             </div>
                         </form>
                     </div>

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -32,7 +32,9 @@ const I18n = (function() {
                 "transactionHistory": "Transaction History",
                 "addPortfolio": "Add Portfolio",
                 "removePortfolio": "Remove Portfolio",
-                "showInSummary": "Show in Summary"
+                "showInSummary": "Show in Summary",
+                "edit": "Edit",
+                "delete": "Delete"
                 },
                 "table": {
                 "ticker": "Ticker",
@@ -57,9 +59,15 @@ const I18n = (function() {
                 "bestTicker": "Best Ticker",
                 "tickerCAGR": "Ticker CAGR",
                 "years": "Years"
+                },
+                "dialogs": {
+                "addInvestment": { "title": "Add Investment" },
+                "editInvestment": { "title": "Edit Investment", "selectRecord": "Select Record" },
+                "totalValue": "Total Value",
+                "saveAddAnother": "Save & Add Another"
                 }
             },
-            "pension": {
+        "pension": {
                 "title": "Pension",
                 "actions": {
                     "addEntry": "Add Entry",
@@ -355,7 +363,9 @@ const I18n = (function() {
                 "transactionHistory": "Historia e Transaksioneve",
                 "addPortfolio": "Shto Portofol",
                 "removePortfolio": "Hiq Portofol",
-                "showInSummary": "Shfaq në Përmbledhje"
+                "showInSummary": "Shfaq në Përmbledhje",
+                "edit": "Redakto",
+                "delete": "Fshi"
                 },
                 "table": {
                 "ticker": "Simboli",
@@ -380,6 +390,12 @@ const I18n = (function() {
                 "bestTicker": "Simboli Më i Mirë",
                 "tickerCAGR": "CAGR i Simbolit",
                 "years": "Vitet"
+                },
+                "dialogs": {
+                "addInvestment": { "title": "Shto Investim" },
+                "editInvestment": { "title": "Redakto Investimin", "selectRecord": "Zgjidh Regjistrimin" },
+                "totalValue": "Vlera Totale",
+                "saveAddAnother": "Ruaj & Shto Tjetër"
                 }
             },
             "pension": {
@@ -680,7 +696,9 @@ const I18n = (function() {
                 "transactionHistory": "Historique des Transactions",
                 "addPortfolio": "Ajouter un Portefeuille",
                 "removePortfolio": "Supprimer le Portefeuille",
-                "showInSummary": "Afficher dans le Résumé"
+                "showInSummary": "Afficher dans le Résumé",
+                "edit": "Modifier",
+                "delete": "Supprimer"
                 },
                 "table": {
                 "ticker": "Symbole",
@@ -705,6 +723,12 @@ const I18n = (function() {
                 "bestTicker": "Meilleur Symbole",
                 "tickerCAGR": "TCAM par Symbole",
                 "years": "Années"
+                },
+                "dialogs": {
+                "addInvestment": { "title": "Ajouter un Investissement" },
+                "editInvestment": { "title": "Modifier l'investissement", "selectRecord": "Sélectionner l'enregistrement" },
+                "totalValue": "Valeur Totale",
+                "saveAddAnother": "Enregistrer et Ajouter un Autre"
                 }
             },
             "pension": {
@@ -1005,7 +1029,9 @@ const I18n = (function() {
                 "transactionHistory": "Transaktionshistorie",
                 "addPortfolio": "Portfolio hinzufügen",
                 "removePortfolio": "Portfolio entfernen",
-                "showInSummary": "In Zusammenfassung anzeigen"
+                "showInSummary": "In Zusammenfassung anzeigen",
+                "edit": "Bearbeiten",
+                "delete": "Löschen"
                 },
                 "table": {
                 "ticker": "Ticker",
@@ -1030,6 +1056,12 @@ const I18n = (function() {
                 "bestTicker": "Bester Ticker",
                 "tickerCAGR": "Ticker-CAGR",
                 "years": "Jahre"
+                },
+                "dialogs": {
+                "addInvestment": { "title": "Investition hinzufügen" },
+                "editInvestment": { "title": "Investition bearbeiten", "selectRecord": "Datensatz auswählen" },
+                "totalValue": "Gesamtwert",
+                "saveAddAnother": "Speichern & Weiteres hinzufügen"
                 }
             },
             "pension": {
@@ -1330,7 +1362,9 @@ const I18n = (function() {
                 "transactionHistory": "Historial de Transacciones",
                 "addPortfolio": "Agregar Cartera",
                 "removePortfolio": "Eliminar Cartera",
-                "showInSummary": "Mostrar en el Resumen"
+                "showInSummary": "Mostrar en el Resumen",
+                "edit": "Editar",
+                "delete": "Eliminar"
                 },
                 "table": {
                 "ticker": "Símbolo",
@@ -1355,6 +1389,12 @@ const I18n = (function() {
                 "bestTicker": "Mejor Símbolo",
                 "tickerCAGR": "CAGR por Símbolo",
                 "years": "Años"
+                },
+                "dialogs": {
+                "addInvestment": { "title": "Agregar Inversión" },
+                "editInvestment": { "title": "Editar Inversión", "selectRecord": "Seleccionar registro" },
+                "totalValue": "Valor Total",
+                "saveAddAnother": "Guardar y Añadir Otro"
                 }
             },
             "pension": {
@@ -1655,7 +1695,9 @@ const I18n = (function() {
                 "transactionHistory": "Storico delle Transazioni",
                 "addPortfolio": "Aggiungi Portafoglio",
                 "removePortfolio": "Rimuovi Portafoglio",
-                "showInSummary": "Mostra nel Riepilogo"
+                "showInSummary": "Mostra nel Riepilogo",
+                "edit": "Modifica",
+                "delete": "Elimina"
                 },
                 "table": {
                 "ticker": "Simbolo",
@@ -1680,6 +1722,12 @@ const I18n = (function() {
                 "bestTicker": "Miglior Simbolo",
                 "tickerCAGR": "CAGR per Simbolo",
                 "years": "Anni"
+                },
+                "dialogs": {
+                "addInvestment": { "title": "Aggiungi Investimento" },
+                "editInvestment": { "title": "Modifica Investimento", "selectRecord": "Seleziona record" },
+                "totalValue": "Valore Totale",
+                "saveAddAnother": "Salva e Aggiungi Un Altro"
                 }
             },
             "pension": {

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -546,10 +546,10 @@ const PortfolioManager = (function() {
                 <td class="pl-cell"></td>
                 <td class="plpct-cell"></td>
                 <td class="actions-cell">
-                    <button class="icon-btn edit-btn" data-index="${inv.index}" title="Edit">
+                    <button class="icon-btn edit-btn" data-index="${inv.index}" title="${I18n.t('portfolio.actions.edit')}">
                         <svg width="16" height="16" viewBox="0 0 512 512"><polygon points="364.13 125.25 87 403 64 448 108.99 425 386.75 147.87 364.13 125.25" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><path d="M420.69,68.69,398.07,91.31l22.62,22.63,22.62-22.63a16,16,0,0,0,0-22.62h0A16,16,0,0,0,420.69,68.69Z" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
-                    <button class="icon-btn delete-btn" data-index="${inv.index}" title="Delete">
+                    <button class="icon-btn delete-btn" data-index="${inv.index}" title="${I18n.t('portfolio.actions.delete')}">
                         <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
                 </td>`;


### PR DESCRIPTION
## Summary
- translate Add/Edit investment modals and form fields for all supported languages
- localize edit and delete titles in portfolio table rows
- add new i18n keys for investment dialogs across locales

## Testing
- `npm test --prefix app/js`

------
https://chatgpt.com/codex/tasks/task_e_6897d91afa54832fbe43ceeadd559490