### PR TITLE
Remove pseudolocalization option and document language policy

### DIFF
--- a/DOCUMENTATION_SUMMARY.md
+++ b/DOCUMENTATION_SUMMARY.md
@@ -223,3 +223,4 @@ This comprehensive documentation package ensures the Personal Finance Dashboard 
 - Documentation updated for modularized codebase.
 - `.gitignore` improvements noted.
 - See [RULES.md](RULES.md) for contribution guidelines.
+- Pseudo locale removed from language selector; internationalization guide updated to add locales via `DEFAULT_TRANSLATIONS` only on developer request.

--- a/I18N_README.md
+++ b/I18N_README.md
@@ -1,16 +1,16 @@
 # Internationalization
 
-The application now supports multiple languages via JSON locale files stored in `app/locales`.
+The application supports multiple languages through built-in translations defined in `app/js/i18n.js`. Optional JSON files in `app/locales` can override these defaults. Currently English, Spanish, French, German, Italian and Albanian are available.
 
 ## Adding a Language
-1. Copy `app/locales/en.json` to `app/locales/{code}.json`.
+1. Add a new entry to the `DEFAULT_TRANSLATIONS` object in `app/js/i18n.js` using the English strings as a template.
 2. Translate each value.
-3. Languages listed in the selector are generated from the keys in `DEFAULT_TRANSLATIONS`, so no additional configuration is required.
+3. (Optional) Provide a matching `app/locales/{code}.json` file if you want to maintain translations outside the script.
+4. Languages listed in the selector are generated from the keys in `DEFAULT_TRANSLATIONS`, so no additional configuration is required.
+
+Language options are added only when requested by a human developer. Pseudolocalisation is not included in the selector by default.
 
 ## Runtime Selection
 The Settings tab provides a language selector and RTL toggle. Chosen locale and direction are stored in `localStorage`.
 
 If the app is opened directly from the filesystem (`file://`), locale files cannot be fetched due to browser restrictions. In that case the built-in English translations are used automatically so the interface remains functional offline.
-
-## Pseudolocalisation
-Select the `pseudo` locale to enable pseudolocalisation for QA.

--- a/RULES.md
+++ b/RULES.md
@@ -10,6 +10,7 @@ This file outlines basic rules and coding standards for the Personal Finance Das
 - Respect the `.gitignore` settings; do not commit dependencies or local build artifacts.
 - Use the built-in `DialogManager` for all alerts, prompts, and confirmation dialogs.
 - Customize portfolio table headers only through the `PortfolioColumns` module.
+- Add new language options (including pseudolocalisation) only when explicitly requested by a human developer.
 
 ## Community Standards
 - Be respectful and collaborative.

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -2019,7 +2019,6 @@ const I18n = (function() {
     }
 
     const availableLocales = Object.keys(DEFAULT_TRANSLATIONS);
-    availableLocales.push('pseudo');
 
     function getLocale() {
         return localStorage.getItem(LOCALE_KEY) || 'en';

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -54,8 +54,7 @@ const Settings = (function() {
                 fr: '🇫🇷',
                 de: '🇩🇪',
                 it: '🇮🇹',
-                sq: '🇦🇱',
-                pseudo: '🏳️'
+                sq: '🇦🇱'
             };
             I18n.availableLocales.forEach(l => {
                 const opt = document.createElement('option');


### PR DESCRIPTION
## Summary
- Drop `pseudo` from available locales and language selector
- Document that new language options are added only at human developer request
- Refresh internationalization docs, clarifying how to add locales through `DEFAULT_TRANSLATIONS`
- Update project documentation summary for the new language policy

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985cddaa04832fabd63a2551b561e0