### PR TITLE
Format financial calculator inputs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -423,7 +423,7 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label for="loan-principal"><span data-i18n="calculators.loan.labels.principal">Principal Amount</span> (<span id="loan-base-currency-label">USD</span>)</label>
-                                <input type="number" id="loan-principal" min="0" step="1000">
+                                <input type="text" id="loan-principal" inputmode="decimal">
                             </div>
                             <div class="form-group">
                                 <label for="loan-rate" data-i18n="calculators.loan.labels.rate">Annual Interest Rate (%)</label>
@@ -458,7 +458,7 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label for="invest-initial"><span data-i18n="calculators.investment.labels.initial">Initial Investment</span> (<span id="invest-base-currency-label">USD</span>)</label>
-                                <input type="number" id="invest-initial" min="0" step="1000">
+                                <input type="text" id="invest-initial" inputmode="decimal">
                             </div>
                             <div class="form-group">
                                 <label for="invest-rate" data-i18n="calculators.investment.labels.rate">Annual Return Rate (%)</label>
@@ -501,11 +501,11 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label for="cagr-beginning" data-i18n="calculators.cagr.labels.beginning">Beginning Value ($)</label>
-                                <input type="number" id="cagr-beginning" min="0" step="1000">
+                                <input type="text" id="cagr-beginning" inputmode="decimal">
                             </div>
                             <div class="form-group">
                                 <label for="cagr-ending" data-i18n="calculators.cagr.labels.ending">Ending Value ($)</label>
-                                <input type="number" id="cagr-ending" min="0" step="1000">
+                                <input type="text" id="cagr-ending" inputmode="decimal">
                             </div>
                             <div class="form-group">
                                 <label for="cagr-years" data-i18n="calculators.cagr.labels.years">Number of Years</label>

--- a/app/js/calculator.js
+++ b/app/js/calculator.js
@@ -18,6 +18,31 @@ const Calculator = (function() {
         return I18n.formatNumber(num, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
     }
 
+    function formatInputValue(value) {
+        const clean = value.replace(/[^0-9.]/g, '');
+        if (clean === '') return '';
+        const [intPart, decPart] = clean.split('.');
+        const formattedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        if (decPart !== undefined) {
+            const decimals = decPart.slice(0, 2).padEnd(2, '0');
+            return `${formattedInt}.${decimals}`;
+        }
+        return formattedInt;
+    }
+
+    function setupAmountInput(id) {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.addEventListener('input', (e) => {
+            e.target.value = formatInputValue(e.target.value);
+        });
+    }
+
+    function getNumberValue(id) {
+        const el = document.getElementById(id);
+        return parseFloat(el.value.replace(/,/g, '')) || 0;
+    }
+
     function updateCurrencyDisplays() {
         const currency = Settings && typeof Settings.getBaseCurrency === 'function'
             ? Settings.getBaseCurrency()
@@ -83,7 +108,7 @@ const Calculator = (function() {
     // Loan Calculator
     const LoanCalculator = (function() {
         function calculate() {
-            const principal = parseFloat(document.getElementById('loan-principal').value) || 0;
+            const principal = getNumberValue('loan-principal');
             const annualRate = parseFloat(document.getElementById('loan-rate').value) || 0;
             const years = parseFloat(document.getElementById('loan-term').value) || 0;
 
@@ -112,6 +137,7 @@ const Calculator = (function() {
             inputs.forEach(id => {
                 document.getElementById(id).addEventListener('input', calculate);
             });
+            setupAmountInput('loan-principal');
         }
 
         return { init };
@@ -120,7 +146,7 @@ const Calculator = (function() {
     // Investment Calculator
     const InvestmentCalculator = (function() {
         function calculate() {
-            const initial = parseFloat(document.getElementById('invest-initial').value) || 0;
+            const initial = getNumberValue('invest-initial');
             const annualRate = parseFloat(document.getElementById('invest-rate').value) || 0;
             const years = parseFloat(document.getElementById('invest-years').value) || 0;
 
@@ -162,6 +188,7 @@ const Calculator = (function() {
             inputs.forEach(id => {
                 document.getElementById(id).addEventListener('input', calculate);
             });
+            setupAmountInput('invest-initial');
         }
 
         return { init };
@@ -170,8 +197,8 @@ const Calculator = (function() {
     // CAGR Calculator
     const CAGRCalculator = (function() {
         function calculate() {
-            const beginning = parseFloat(document.getElementById('cagr-beginning').value) || 0;
-            const ending = parseFloat(document.getElementById('cagr-ending').value) || 0;
+            const beginning = getNumberValue('cagr-beginning');
+            const ending = getNumberValue('cagr-ending');
             const years = parseFloat(document.getElementById('cagr-years').value) || 0;
 
             if (beginning <= 0 || ending <= 0 || years <= 0) {
@@ -192,6 +219,8 @@ const Calculator = (function() {
             inputs.forEach(id => {
                 document.getElementById(id).addEventListener('input', calculate);
             });
+            setupAmountInput('cagr-beginning');
+            setupAmountInput('cagr-ending');
         }
 
         return { init };


### PR DESCRIPTION
## Summary
- format loan principal, investment initial, and CAGR beginning/ending inputs with thousands separators and two-decimal precision
- parse formatted amounts in calculator logic for accurate calculations

## Testing
- `cd app/js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986ab30dac832f9ad1442603247c2e