### PR TITLE
Format numeric inputs in calculators and pensions

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -352,7 +352,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="pension-entry-value" data-i18n="pension.table.currentValue">Current Value</label>
-                                <input type="number" step="0.01" id="pension-entry-value" required>
+                                <input type="text" inputmode="decimal" id="pension-entry-value" required>
                             </div>
                             <div class="form-group" id="payment-group">
                                 <label for="pension-entry-payment" data-i18n="pension.table.payment">Payment</label>
@@ -377,7 +377,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="pension-edit-value" data-i18n="pension.table.currentValue">Current Value</label>
-                                <input type="number" step="0.01" id="pension-edit-value" required>
+                                <input type="text" inputmode="decimal" id="pension-edit-value" required>
                             </div>
                             <div class="form-group" id="edit-payment-group">
                                 <label for="pension-edit-payment" data-i18n="pension.table.payment">Payment</label>
@@ -544,7 +544,7 @@
                                 <div class="form-grid">
                                     <div class="form-group">
                                         <label for="dcf-current-fcf"><span data-i18n="calculators.fairValue.dcf.labels.currentFCF">Current Annual Free Cash Flow</span> ($M)</label>
-                                        <input type="number" id="dcf-current-fcf" min="0" step="10">
+                                        <input type="text" id="dcf-current-fcf" inputmode="decimal">
                                     </div>
                                     <div class="form-group">
                                         <label for="dcf-growth-rate" data-i18n="calculators.fairValue.dcf.labels.growthRate">Growth Rate (%)</label>
@@ -564,7 +564,7 @@
                                     </div>
                                     <div class="form-group">
                                         <label for="dcf-shares" data-i18n="calculators.fairValue.dcf.labels.shares">Shares Outstanding (M)</label>
-                                        <input type="number" id="dcf-shares" min="1" step="0.1">
+                                        <input type="text" id="dcf-shares" inputmode="decimal">
                                     </div>
                                 </div>
                                 <div id="dcf-results" class="result-display" style="display: none;">
@@ -593,7 +593,7 @@
                                 <div class="form-grid">
                                     <div class="form-group">
                                         <label for="pe-current-price" data-i18n="calculators.fairValue.pe.labels.currentPrice">Current Stock Price ($)</label>
-                                        <input type="number" id="pe-current-price" min="0" step="0.01">
+                                        <input type="text" id="pe-current-price" inputmode="decimal">
                                     </div>
                                     <div class="form-group">
                                         <label for="pe-eps" data-i18n="calculators.fairValue.pe.labels.eps">Earnings Per Share (EPS) ($)</label>

--- a/app/js/calculator.js
+++ b/app/js/calculator.js
@@ -232,12 +232,12 @@ const Calculator = (function() {
         // DCF Calculator
         const DCFCalculator = (function() {
             function calculate() {
-                const currentFCF = parseFloat(document.getElementById('dcf-current-fcf').value) || 0;
+                const currentFCF = getNumberValue('dcf-current-fcf');
                 const growthRate = parseFloat(document.getElementById('dcf-growth-rate').value) || 0;
                 const terminalRate = parseFloat(document.getElementById('dcf-terminal-rate').value) || 0;
                 const discountRate = parseFloat(document.getElementById('dcf-discount-rate').value) || 0;
                 const projectionYears = parseInt(document.getElementById('dcf-years').value) || 0;
-                const sharesOutstanding = parseFloat(document.getElementById('dcf-shares').value) || 0;
+                const sharesOutstanding = getNumberValue('dcf-shares');
 
                 if (currentFCF <= 0 || discountRate <= 0 || projectionYears <= 0 || sharesOutstanding <= 0) {
                     document.getElementById('dcf-results').style.display = 'none';
@@ -273,6 +273,8 @@ const Calculator = (function() {
             }
 
             function init() {
+                setupAmountInput('dcf-current-fcf');
+                setupAmountInput('dcf-shares');
                 const inputs = ['dcf-current-fcf', 'dcf-growth-rate', 'dcf-terminal-rate', 'dcf-discount-rate', 'dcf-years', 'dcf-shares'];
                 inputs.forEach(id => {
                     document.getElementById(id).addEventListener('input', calculate);
@@ -285,7 +287,7 @@ const Calculator = (function() {
         // P/E Ratio Calculator
         const PECalculator = (function() {
             function calculate() {
-                const currentPrice = parseFloat(document.getElementById('pe-current-price').value) || 0;
+                const currentPrice = getNumberValue('pe-current-price');
                 const eps = parseFloat(document.getElementById('pe-eps').value) || 0;
                 const industryPE = parseFloat(document.getElementById('pe-industry-avg').value) || 0;
                 const growthRate = parseFloat(document.getElementById('pe-growth-rate').value) || 0;
@@ -318,6 +320,7 @@ const Calculator = (function() {
             }
 
             function init() {
+                setupAmountInput('pe-current-price');
                 const inputs = ['pe-current-price', 'pe-eps', 'pe-industry-avg', 'pe-growth-rate'];
                 inputs.forEach(id => {
                     document.getElementById(id).addEventListener('input', calculate);

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -49,6 +49,25 @@ const PensionManager = (function() {
     const chartClose = document.getElementById('pension-chart-close');
     let pensionChart = null;
 
+    function formatInputValue(value) {
+        const clean = value.replace(/[^0-9.]/g, '');
+        if (clean === '') return '';
+        const [intPart, decPart] = clean.split('.');
+        const formattedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        if (decPart !== undefined) {
+            const decimals = decPart.slice(0, 2).padEnd(2, '0');
+            return `${formattedInt}.${decimals}`;
+        }
+        return formattedInt;
+    }
+
+    function setupAmountInput(input) {
+        if (!input) return;
+        input.addEventListener('input', (e) => {
+            e.target.value = formatInputValue(e.target.value);
+        });
+    }
+
     function getStorageKey(id) {
         return STORAGE_PREFIX + id;
     }
@@ -235,7 +254,7 @@ const PensionManager = (function() {
         e.preventDefault();
         if (summaryMode) return;
         const date = entryDateInput.value;
-        const value = parseFloat(entryValueInput.value);
+        const value = parseFloat(entryValueInput.value.replace(/,/g, ''));
         const payment = parseFloat(entryPaymentInput.value) || 0;
         if (!date || isNaN(value)) return;
         entries.push({ date, value, payment });
@@ -251,7 +270,7 @@ const PensionManager = (function() {
         const entry = entries[idx];
         if (!entry) return;
         editDateInput.value = entry.date;
-        editValueInput.value = entry.value;
+        editValueInput.value = formatInputValue(String(entry.value));
         editPaymentInput.value = entry.payment || '';
         const current = pensions.find(p => p.id === currentPensionId);
         if (current && current.type === 'growth') {
@@ -273,7 +292,7 @@ const PensionManager = (function() {
         if (summaryMode) return;
         if (editIndex === null) return;
         const date = editDateInput.value;
-        const value = parseFloat(editValueInput.value);
+        const value = parseFloat(editValueInput.value.replace(/,/g, ''));
         const payment = parseFloat(editPaymentInput.value) || 0;
         if (!date || isNaN(value)) return;
         entries[editIndex] = { date, value, payment };
@@ -551,6 +570,8 @@ const PensionManager = (function() {
     }
 
     function init() {
+        setupAmountInput(entryValueInput);
+        setupAmountInput(editValueInput);
         loadPensionList();
         loadEntries();
         renderTabs();


### PR DESCRIPTION
## Summary
- Format Fair Value Calculator inputs for current FCF, shares outstanding, and stock price with thousands separators and decimals
- Add inline formatting and parsing for pension entry and edit value fields
- Parse formatted values when calculating DCF and P/E metrics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68986e326f9c832f8ec8a642dabec217