### PR TITLE
feat: add watchlist tab

### DIFF
--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -39,7 +39,7 @@ test('watchlist tab and table headers exist', () => {
   const tab = doc.querySelector('button.nav-tab[data-tab="watchlist"]');
   expect(tab).not.toBeNull();
   const headers = Array.from(doc.querySelectorAll('#watchlist-table thead th')).map(th => th.textContent.trim());
-  ['Ticker','Name','Currency','Current Price','Change','Change %','High','Low','Open Price','Previous Close'].forEach(h => {
+  ['Ticker','Name','Currency','Current Price','Change','Change %','High','Low','Open Price','Previous Close','Actions'].forEach(h => {
     expect(headers).toContain(h);
   });
 });

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -31,6 +31,19 @@ test('header contains market status indicator', () => {
   expect(doc.getElementById('after-led')).not.toBeNull();
 });
 
+test('watchlist tab and table headers exist', () => {
+  const htmlPath = path.resolve(__dirname, '../app/index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const tab = doc.querySelector('button.nav-tab[data-tab="watchlist"]');
+  expect(tab).not.toBeNull();
+  const headers = Array.from(doc.querySelectorAll('#watchlist-table thead th')).map(th => th.textContent.trim());
+  ['Ticker','Name','Currency','Current Price','Change','Change %','High','Low','Open Price','Previous Close'].forEach(h => {
+    expect(headers).toContain(h);
+  });
+});
+
 test('portfolio table includes currency column', () => {
   const htmlPath = path.resolve(__dirname, '../app/index.html');
   const html = fs.readFileSync(htmlPath, 'utf8');

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -15,6 +15,7 @@ test('FinancialDashboard global object exists with init and removeTicker', () =>
     'tabManager.js',
     'portfolioStorage.js',
     'portfolioManager.js',
+    'watchlistManager.js',
     'pensionManager.js',
     'calculator.js',
     'stockTracker.js',
@@ -466,5 +467,15 @@ test('StockTracker exposes fetchLatestPrices', () => {
   const code = fs.readFileSync(path.resolve(__dirname, '../app/js/stockTracker.js'), 'utf8');
   vm.runInContext(code, context);
   const fnType = vm.runInContext('typeof StockTracker.fetchLatestPrices', context);
+  expect(fnType).toBe('function');
+});
+
+test('WatchlistManager exposes fetchLastPrices', () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
+  const context = vm.createContext(dom.window);
+  vm.runInContext(i18nCode, context);
+  const code = fs.readFileSync(path.resolve(__dirname, '../app/js/watchlistManager.js'), 'utf8');
+  vm.runInContext(code, context);
+  const fnType = vm.runInContext('typeof WatchlistManager.fetchLastPrices', context);
   expect(fnType).toBe('function');
 });

--- a/app/index.html
+++ b/app/index.html
@@ -281,6 +281,7 @@
                                 <th data-i18n="watchlist.table.low">Low</th>
                                 <th data-i18n="watchlist.table.open">Open Price</th>
                                 <th data-i18n="watchlist.table.prevClose">Previous Close</th>
+                                <th data-i18n="watchlist.table.actions">Actions</th>
                             </tr>
                         </thead>
                         <tbody id="watchlist-body"></tbody>

--- a/app/index.html
+++ b/app/index.html
@@ -39,6 +39,7 @@
 
     <nav class="nav-tabs">
         <button class="nav-tab active" data-tab="portfolio" data-i18n="nav.portfolio">Portfolio</button>
+        <button class="nav-tab" data-tab="watchlist" data-i18n="nav.watchlist">Watchlist</button>
         <button class="nav-tab" data-tab="pension" data-i18n="nav.pension">Pension</button>
         <button class="nav-tab" data-tab="calculators" data-i18n="nav.calculators">Calculators</button>
         <button class="nav-tab" data-tab="stock-tracker" data-i18n="nav.stockTracker">Stock Performance Tracker</button>
@@ -251,6 +252,69 @@
                                 <tbody id="transaction-history-body"></tbody>
                             </table>
                         </div>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Watchlist Tab -->
+            <div id="watchlist" class="tab-content">
+                <div class="section-header">
+                    <h2 class="section-title" data-i18n="watchlist.title">Watchlist</h2>
+                    <div class="watchlist-actions">
+                        <div class="action-buttons">
+                            <button class="btn btn-primary" id="add-watchstock-btn" data-i18n="watchlist.actions.addStock">Add Stock</button>
+                            <button class="btn btn-secondary" id="watchlist-get-price-btn" data-i18n="watchlist.actions.getLastPrice">Get The Last Price</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="table-container" id="watchlist-table-container">
+                    <table class="data-table" id="watchlist-table">
+                        <thead>
+                            <tr>
+                                <th data-i18n="watchlist.table.ticker">Ticker</th>
+                                <th data-i18n="watchlist.table.name">Name</th>
+                                <th data-i18n="watchlist.table.currency">Currency</th>
+                                <th data-i18n="watchlist.table.currentPrice">Current Price</th>
+                                <th data-i18n="watchlist.table.change">Change</th>
+                                <th data-i18n="watchlist.table.changePct">Change %</th>
+                                <th data-i18n="watchlist.table.high">High</th>
+                                <th data-i18n="watchlist.table.low">Low</th>
+                                <th data-i18n="watchlist.table.open">Open Price</th>
+                                <th data-i18n="watchlist.table.prevClose">Previous Close</th>
+                            </tr>
+                        </thead>
+                        <tbody id="watchlist-body"></tbody>
+                    </table>
+                </div>
+
+                <!-- Add Stock Modal -->
+                <div id="watchlist-modal" class="modal">
+                    <div class="modal-content">
+                        <span class="modal-close" id="watchlist-close">&times;</span>
+                        <h3 data-i18n="watchlist.dialogs.addStock.title">Add Stock</h3>
+                        <form id="watchlist-form">
+                            <div class="form-grid">
+                                <div class="form-group">
+                                    <label for="watchlist-ticker" data-i18n="watchlist.table.ticker">Ticker</label>
+                                    <input type="text" id="watchlist-ticker" style="text-transform: uppercase;" required>
+                                </div>
+                                <div class="form-group">
+                                    <label for="watchlist-name" data-i18n="watchlist.table.name">Name</label>
+                                    <input type="text" id="watchlist-name">
+                                </div>
+                                <div class="form-group">
+                                    <label for="watchlist-currency" data-i18n="watchlist.table.currency">Currency</label>
+                                    <select id="watchlist-currency">
+                                        <option value="USD">USD</option>
+                                        <option value="GBP">GBP</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="modal-actions">
+                                <button type="button" class="btn btn-secondary" id="watchlist-cancel-btn" data-i18n="common.cancel">Cancel</button>
+                                <button type="submit" class="btn btn-primary" data-i18n="common.add">Add</button>
+                            </div>
+                        </form>
                     </div>
                 </div>
             </div>
@@ -1016,6 +1080,7 @@
     <script src="js/colorService.js"></script>
     <script src="js/quotesService.js"></script>
     <script src="js/portfolioManager.js"></script>
+    <script src="js/watchlistManager.js"></script>
     <script src="js/pensionManager.js"></script>
     <script src="js/calculator.js"></script>
     <script src="js/stockTracker.js"></script>

--- a/app/js/financialDashboard.js
+++ b/app/js/financialDashboard.js
@@ -5,6 +5,7 @@ const FinancialDashboard = (function() {
         TabManager.init();
         Settings.init();
         PortfolioManager.init();
+        WatchlistManager.init();
         PensionManager.init();
         Calculator.init();
         StockTracker.init();

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -19,6 +19,7 @@ const I18n = (function() {
             },
             "nav": {
                 "portfolio": "Portfolio",
+                "watchlist": "Watchlist",
                 "pension": "Pension",
                 "calculators": "Calculators",
                 "stockTracker": "Stock Performance Tracker",
@@ -65,6 +66,28 @@ const I18n = (function() {
                 "editInvestment": { "title": "Edit Investment", "selectRecord": "Select Record" },
                 "totalValue": "Total Value",
                 "saveAddAnother": "Save & Add Another"
+                }
+            },
+            "watchlist": {
+                "title": "Watchlist",
+                "actions": {
+                    "addStock": "Add Stock",
+                    "getLastPrice": "Get The Last Price"
+                },
+                "table": {
+                    "ticker": "Ticker",
+                    "name": "Name",
+                    "currency": "Currency",
+                    "currentPrice": "Current Price",
+                    "change": "Change",
+                    "changePct": "Change %",
+                    "high": "High",
+                    "low": "Low",
+                    "open": "Open Price",
+                    "prevClose": "Previous Close"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Add Stock" }
                 }
             },
         "pension": {
@@ -354,8 +377,9 @@ const I18n = (function() {
                 "status": "Statusi i Tregut",
                 "after": "Pas Mbylljes së Tregut"
             },
-            "nav": {
+           "nav": {
                 "portfolio": "Portofoli",
+                "watchlist": "Lista e Vëzhgimit",
                 "pension": "Pensioni",
                 "calculators": "Kalkulatorë",
                 "stockTracker": "Ndjekësi i Performancës së Aksioneve",
@@ -402,6 +426,138 @@ const I18n = (function() {
                 "editInvestment": { "title": "Redakto Investimin", "selectRecord": "Zgjidh Regjistrimin" },
                 "totalValue": "Vlera Totale",
                 "saveAddAnother": "Ruaj & Shto Tjetër"
+                }
+            },
+            "watchlist": {
+                "title": "Lista e Vëzhgimit",
+                "actions": {
+                    "addStock": "Shto Aksion",
+                    "getLastPrice": "Merr Çmimin e Fundit"
+                },
+                "table": {
+                    "ticker": "Simboli",
+                    "name": "Emri",
+                    "currency": "Monedha",
+                    "currentPrice": "Çmimi Aktual",
+                    "change": "Ndryshimi",
+                    "changePct": "Ndryshimi %",
+                    "high": "Më i Larti",
+                    "low": "Më i Ulëti",
+                    "open": "Çmimi i Hapjes",
+                    "prevClose": "Mbyllja e Mëparshme"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Shto Aksion" }
+                }
+            },
+            "watchlist": {
+                "title": "Liste de surveillance",
+                "actions": {
+                    "addStock": "Ajouter une action",
+                    "getLastPrice": "Obtenir le dernier prix"
+                },
+                "table": {
+                    "ticker": "Symbole",
+                    "name": "Nom",
+                    "currency": "Devise",
+                    "currentPrice": "Prix actuel",
+                    "change": "Changement",
+                    "changePct": "Changement %",
+                    "high": "Haut",
+                    "low": "Bas",
+                    "open": "Prix d'ouverture",
+                    "prevClose": "Clôture précédente"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Ajouter une action" }
+                }
+            },
+            "watchlist": {
+                "title": "Beobachtungsliste",
+                "actions": {
+                    "addStock": "Aktie hinzufügen",
+                    "getLastPrice": "Letzten Preis abrufen"
+                },
+                "table": {
+                    "ticker": "Ticker",
+                    "name": "Name",
+                    "currency": "Währung",
+                    "currentPrice": "Aktueller Preis",
+                    "change": "Veränderung",
+                    "changePct": "Veränderung %",
+                    "high": "Hoch",
+                    "low": "Tief",
+                    "open": "Eröffnungspreis",
+                    "prevClose": "Vorheriger Schluss"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Aktie hinzufügen" }
+                }
+            },
+            "watchlist": {
+                "title": "Lista de seguimiento",
+                "actions": {
+                    "addStock": "Agregar acción",
+                    "getLastPrice": "Obtener el último precio"
+                },
+                "table": {
+                    "ticker": "Símbolo",
+                    "name": "Nombre",
+                    "currency": "Moneda",
+                    "currentPrice": "Precio actual",
+                    "change": "Cambio",
+                    "changePct": "Cambio %",
+                    "high": "Alto",
+                    "low": "Bajo",
+                    "open": "Precio de apertura",
+                    "prevClose": "Cierre previo"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Agregar acción" }
+                }
+            },
+            "watchlist": {
+                "title": "Lista di osservazione",
+                "actions": {
+                    "addStock": "Aggiungi titolo",
+                    "getLastPrice": "Ottieni l'ultimo prezzo"
+                },
+                "table": {
+                    "ticker": "Ticker",
+                    "name": "Nome",
+                    "currency": "Valuta",
+                    "currentPrice": "Prezzo attuale",
+                    "change": "Variazione",
+                    "changePct": "Variazione %",
+                    "high": "Massimo",
+                    "low": "Minimo",
+                    "open": "Prezzo di apertura",
+                    "prevClose": "Chiusura precedente"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Aggiungi titolo" }
+                }
+            },
+            "watchlist": {
+                "title": "Listă de urmărire",
+                "actions": {
+                    "addStock": "Adaugă acțiune",
+                    "getLastPrice": "Obține ultimul preț"
+                },
+                "table": {
+                    "ticker": "Simbol",
+                    "name": "Nume",
+                    "currency": "Monedă",
+                    "currentPrice": "Preț curent",
+                    "change": "Schimbare",
+                    "changePct": "Schimbare %",
+                    "high": "Maxim",
+                    "low": "Minim",
+                    "open": "Preț de deschidere",
+                    "prevClose": "Închidere anterioară"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Adaugă acțiune" }
                 }
             },
             "pension": {
@@ -695,6 +851,7 @@ const I18n = (function() {
             },
             "nav": {
                 "portfolio": "Portefeuille",
+                "watchlist": "Liste de surveillance",
                 "pension": "Pension",
                 "calculators": "Calculatrices",
                 "stockTracker": "Suivi de Performance des Actions",
@@ -1034,6 +1191,7 @@ const I18n = (function() {
             },
             "nav": {
                 "portfolio": "Portfolio",
+                "watchlist": "Beobachtungsliste",
                 "pension": "Rente",
                 "calculators": "Rechner",
                 "stockTracker": "Aktien-Performance-Tracker",
@@ -1373,6 +1531,7 @@ const I18n = (function() {
             },
             "nav": {
                 "portfolio": "Cartera",
+                "watchlist": "Lista de seguimiento",
                 "pension": "Pensión",
                 "calculators": "Calculadoras",
                 "stockTracker": "Rastreador de Rendimiento de Acciones",
@@ -1712,6 +1871,7 @@ const I18n = (function() {
             },
             "nav": {
                 "portfolio": "Portafoglio",
+                "watchlist": "Lista di osservazione",
                 "pension": "Pensione",
                 "calculators": "Calcolatrici",
                 "stockTracker": "Tracker delle Prestazioni Azionarie",
@@ -2052,6 +2212,7 @@ const I18n = (function() {
             },
             "nav": {
                 "portfolio": "Portofoliu",
+                "watchlist": "Listă de urmărire",
                 "pension": "Pensiune",
                 "calculators": "Calculatoare",
                 "stockTracker": "Monitorizare performanță acțiuni",

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -72,7 +72,8 @@ const I18n = (function() {
                 "title": "Watchlist",
                 "actions": {
                     "addStock": "Add Stock",
-                    "getLastPrice": "Get The Last Price"
+                    "getLastPrice": "Get The Last Price",
+                    "delete": "Delete"
                 },
                 "table": {
                     "ticker": "Ticker",
@@ -84,7 +85,8 @@ const I18n = (function() {
                     "high": "High",
                     "low": "Low",
                     "open": "Open Price",
-                    "prevClose": "Previous Close"
+                    "prevClose": "Previous Close",
+                    "actions": "Actions"
                 },
                 "dialogs": {
                     "addStock": { "title": "Add Stock" }
@@ -432,7 +434,8 @@ const I18n = (function() {
                 "title": "Lista e Vëzhgimit",
                 "actions": {
                     "addStock": "Shto Aksion",
-                    "getLastPrice": "Merr Çmimin e Fundit"
+                    "getLastPrice": "Merr Çmimin e Fundit",
+                    "delete": "Fshi"
                 },
                 "table": {
                     "ticker": "Simboli",
@@ -444,7 +447,8 @@ const I18n = (function() {
                     "high": "Më i Larti",
                     "low": "Më i Ulëti",
                     "open": "Çmimi i Hapjes",
-                    "prevClose": "Mbyllja e Mëparshme"
+                    "prevClose": "Mbyllja e Mëparshme",
+                    "actions": "Veprimet"
                 },
                 "dialogs": {
                     "addStock": { "title": "Shto Aksion" }
@@ -794,7 +798,8 @@ const I18n = (function() {
                 "title": "Liste de surveillance",
                 "actions": {
                     "addStock": "Ajouter une action",
-                    "getLastPrice": "Obtenir le dernier prix"
+                    "getLastPrice": "Obtenir le dernier prix",
+                    "delete": "Supprimer"
                 },
                 "table": {
                     "ticker": "Symbole",
@@ -806,7 +811,8 @@ const I18n = (function() {
                     "high": "Haut",
                     "low": "Bas",
                     "open": "Prix d'ouverture",
-                    "prevClose": "Clôture précédente"
+                    "prevClose": "Clôture précédente",
+                    "actions": "Actions"
                 },
                 "dialogs": {
                     "addStock": { "title": "Ajouter une action" }
@@ -1156,7 +1162,8 @@ const I18n = (function() {
                 "title": "Beobachtungsliste",
                 "actions": {
                     "addStock": "Aktie hinzufügen",
-                    "getLastPrice": "Letzten Preis abrufen"
+                    "getLastPrice": "Letzten Preis abrufen",
+                    "delete": "Löschen"
                 },
                 "table": {
                     "ticker": "Ticker",
@@ -1168,7 +1175,8 @@ const I18n = (function() {
                     "high": "Hoch",
                     "low": "Tief",
                     "open": "Eröffnungspreis",
-                    "prevClose": "Vorheriger Schluss"
+                    "prevClose": "Vorheriger Schluss",
+                    "actions": "Aktionen"
                 },
                 "dialogs": {
                     "addStock": { "title": "Aktie hinzufügen" }
@@ -1518,7 +1526,8 @@ const I18n = (function() {
                 "title": "Lista de seguimiento",
                 "actions": {
                     "addStock": "Agregar acción",
-                    "getLastPrice": "Obtener el último precio"
+                    "getLastPrice": "Obtener el último precio",
+                    "delete": "Eliminar"
                 },
                 "table": {
                     "ticker": "Símbolo",
@@ -1530,7 +1539,8 @@ const I18n = (function() {
                     "high": "Alto",
                     "low": "Bajo",
                     "open": "Precio de apertura",
-                    "prevClose": "Cierre previo"
+                    "prevClose": "Cierre previo",
+                    "actions": "Acciones"
                 },
                 "dialogs": {
                     "addStock": { "title": "Agregar acción" }
@@ -1880,7 +1890,8 @@ const I18n = (function() {
                 "title": "Lista di osservazione",
                 "actions": {
                     "addStock": "Aggiungi titolo",
-                    "getLastPrice": "Ottieni l'ultimo prezzo"
+                    "getLastPrice": "Ottieni l'ultimo prezzo",
+                    "delete": "Elimina"
                 },
                 "table": {
                     "ticker": "Ticker",
@@ -1892,7 +1903,8 @@ const I18n = (function() {
                     "high": "Massimo",
                     "low": "Minimo",
                     "open": "Prezzo di apertura",
-                    "prevClose": "Chiusura precedente"
+                    "prevClose": "Chiusura precedente",
+                    "actions": "Azioni"
                 },
                 "dialogs": {
                     "addStock": { "title": "Aggiungi titolo" }
@@ -2248,7 +2260,8 @@ const I18n = (function() {
                 "title": "Listă de urmărire",
                 "actions": {
                     "addStock": "Adaugă acțiune",
-                    "getLastPrice": "Obține ultimul preț"
+                    "getLastPrice": "Obține ultimul preț",
+                    "delete": "Șterge"
                 },
                 "table": {
                     "ticker": "Simbol",
@@ -2260,7 +2273,8 @@ const I18n = (function() {
                     "high": "Maxim",
                     "low": "Minim",
                     "open": "Preț de deschidere",
-                    "prevClose": "Închidere anterioară"
+                    "prevClose": "Închidere anterioară",
+                    "actions": "Acțiuni"
                 },
                 "dialogs": {
                     "addStock": { "title": "Adaugă acțiune" }

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -89,7 +89,8 @@ const I18n = (function() {
                     "actions": "Actions"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Add Stock" }
+                    "addStock": { "title": "Add Stock" },
+                    "deleteStock": "Delete this stock?"
                 }
             },
         "pension": {
@@ -451,7 +452,8 @@ const I18n = (function() {
                     "actions": "Veprimet"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Shto Aksion" }
+                    "addStock": { "title": "Shto Aksion" },
+                    "deleteStock": "Ta fshij këtë aksion?"
                 }
             },
             "pension": {
@@ -815,7 +817,8 @@ const I18n = (function() {
                     "actions": "Actions"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Ajouter une action" }
+                    "addStock": { "title": "Ajouter une action" },
+                    "deleteStock": "Supprimer cette action ?",
                 }
             },
             "pension": {
@@ -1179,7 +1182,8 @@ const I18n = (function() {
                     "actions": "Aktionen"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Aktie hinzufügen" }
+                    "addStock": { "title": "Aktie hinzufügen" },
+                    "deleteStock": "Diese Aktie löschen?",
                 }
             },
             "pension": {
@@ -1543,7 +1547,8 @@ const I18n = (function() {
                     "actions": "Acciones"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Agregar acción" }
+                    "addStock": { "title": "Agregar acción" },
+                    "deleteStock": "¿Eliminar esta acción?",
                 }
             },
             "pension": {
@@ -1907,7 +1912,8 @@ const I18n = (function() {
                     "actions": "Azioni"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Aggiungi titolo" }
+                    "addStock": { "title": "Aggiungi titolo" },
+                    "deleteStock": "Eliminare questa azione?",
                 }
             },
             "pension": {
@@ -2277,7 +2283,8 @@ const I18n = (function() {
                     "actions": "Acțiuni"
                 },
                 "dialogs": {
-                    "addStock": { "title": "Adaugă acțiune" }
+                    "addStock": { "title": "Adaugă acțiune" },
+                    "deleteStock": "Ștergeți această acțiune?",
                 }
             },
             "pension": {

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -450,116 +450,6 @@ const I18n = (function() {
                     "addStock": { "title": "Shto Aksion" }
                 }
             },
-            "watchlist": {
-                "title": "Liste de surveillance",
-                "actions": {
-                    "addStock": "Ajouter une action",
-                    "getLastPrice": "Obtenir le dernier prix"
-                },
-                "table": {
-                    "ticker": "Symbole",
-                    "name": "Nom",
-                    "currency": "Devise",
-                    "currentPrice": "Prix actuel",
-                    "change": "Changement",
-                    "changePct": "Changement %",
-                    "high": "Haut",
-                    "low": "Bas",
-                    "open": "Prix d'ouverture",
-                    "prevClose": "Clôture précédente"
-                },
-                "dialogs": {
-                    "addStock": { "title": "Ajouter une action" }
-                }
-            },
-            "watchlist": {
-                "title": "Beobachtungsliste",
-                "actions": {
-                    "addStock": "Aktie hinzufügen",
-                    "getLastPrice": "Letzten Preis abrufen"
-                },
-                "table": {
-                    "ticker": "Ticker",
-                    "name": "Name",
-                    "currency": "Währung",
-                    "currentPrice": "Aktueller Preis",
-                    "change": "Veränderung",
-                    "changePct": "Veränderung %",
-                    "high": "Hoch",
-                    "low": "Tief",
-                    "open": "Eröffnungspreis",
-                    "prevClose": "Vorheriger Schluss"
-                },
-                "dialogs": {
-                    "addStock": { "title": "Aktie hinzufügen" }
-                }
-            },
-            "watchlist": {
-                "title": "Lista de seguimiento",
-                "actions": {
-                    "addStock": "Agregar acción",
-                    "getLastPrice": "Obtener el último precio"
-                },
-                "table": {
-                    "ticker": "Símbolo",
-                    "name": "Nombre",
-                    "currency": "Moneda",
-                    "currentPrice": "Precio actual",
-                    "change": "Cambio",
-                    "changePct": "Cambio %",
-                    "high": "Alto",
-                    "low": "Bajo",
-                    "open": "Precio de apertura",
-                    "prevClose": "Cierre previo"
-                },
-                "dialogs": {
-                    "addStock": { "title": "Agregar acción" }
-                }
-            },
-            "watchlist": {
-                "title": "Lista di osservazione",
-                "actions": {
-                    "addStock": "Aggiungi titolo",
-                    "getLastPrice": "Ottieni l'ultimo prezzo"
-                },
-                "table": {
-                    "ticker": "Ticker",
-                    "name": "Nome",
-                    "currency": "Valuta",
-                    "currentPrice": "Prezzo attuale",
-                    "change": "Variazione",
-                    "changePct": "Variazione %",
-                    "high": "Massimo",
-                    "low": "Minimo",
-                    "open": "Prezzo di apertura",
-                    "prevClose": "Chiusura precedente"
-                },
-                "dialogs": {
-                    "addStock": { "title": "Aggiungi titolo" }
-                }
-            },
-            "watchlist": {
-                "title": "Listă de urmărire",
-                "actions": {
-                    "addStock": "Adaugă acțiune",
-                    "getLastPrice": "Obține ultimul preț"
-                },
-                "table": {
-                    "ticker": "Simbol",
-                    "name": "Nume",
-                    "currency": "Monedă",
-                    "currentPrice": "Preț curent",
-                    "change": "Schimbare",
-                    "changePct": "Schimbare %",
-                    "high": "Maxim",
-                    "low": "Minim",
-                    "open": "Preț de deschidere",
-                    "prevClose": "Închidere anterioară"
-                },
-                "dialogs": {
-                    "addStock": { "title": "Adaugă acțiune" }
-                }
-            },
             "pension": {
                 "title": "Pensioni",
                 "actions": {
@@ -898,6 +788,28 @@ const I18n = (function() {
                 "editInvestment": { "title": "Modifier l'investissement", "selectRecord": "Sélectionner l'enregistrement" },
                 "totalValue": "Valeur Totale",
                 "saveAddAnother": "Enregistrer et Ajouter un Autre"
+                }
+            },
+            "watchlist": {
+                "title": "Liste de surveillance",
+                "actions": {
+                    "addStock": "Ajouter une action",
+                    "getLastPrice": "Obtenir le dernier prix"
+                },
+                "table": {
+                    "ticker": "Symbole",
+                    "name": "Nom",
+                    "currency": "Devise",
+                    "currentPrice": "Prix actuel",
+                    "change": "Changement",
+                    "changePct": "Changement %",
+                    "high": "Haut",
+                    "low": "Bas",
+                    "open": "Prix d'ouverture",
+                    "prevClose": "Clôture précédente"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Ajouter une action" }
                 }
             },
             "pension": {
@@ -1240,6 +1152,28 @@ const I18n = (function() {
                 "saveAddAnother": "Speichern & Weiteres hinzufügen"
                 }
             },
+            "watchlist": {
+                "title": "Beobachtungsliste",
+                "actions": {
+                    "addStock": "Aktie hinzufügen",
+                    "getLastPrice": "Letzten Preis abrufen"
+                },
+                "table": {
+                    "ticker": "Ticker",
+                    "name": "Name",
+                    "currency": "Währung",
+                    "currentPrice": "Aktueller Preis",
+                    "change": "Veränderung",
+                    "changePct": "Veränderung %",
+                    "high": "Hoch",
+                    "low": "Tief",
+                    "open": "Eröffnungspreis",
+                    "prevClose": "Vorheriger Schluss"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Aktie hinzufügen" }
+                }
+            },
             "pension": {
                 "title": "Rente",
                 "actions": {
@@ -1580,6 +1514,28 @@ const I18n = (function() {
                 "saveAddAnother": "Guardar y Añadir Otro"
                 }
             },
+            "watchlist": {
+                "title": "Lista de seguimiento",
+                "actions": {
+                    "addStock": "Agregar acción",
+                    "getLastPrice": "Obtener el último precio"
+                },
+                "table": {
+                    "ticker": "Símbolo",
+                    "name": "Nombre",
+                    "currency": "Moneda",
+                    "currentPrice": "Precio actual",
+                    "change": "Cambio",
+                    "changePct": "Cambio %",
+                    "high": "Alto",
+                    "low": "Bajo",
+                    "open": "Precio de apertura",
+                    "prevClose": "Cierre previo"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Agregar acción" }
+                }
+            },
             "pension": {
                 "title": "Pensión",
                 "actions": {
@@ -1918,6 +1874,28 @@ const I18n = (function() {
                 "editInvestment": { "title": "Modifica Investimento", "selectRecord": "Seleziona record" },
                 "totalValue": "Valore Totale",
                 "saveAddAnother": "Salva e Aggiungi Un Altro"
+                }
+            },
+            "watchlist": {
+                "title": "Lista di osservazione",
+                "actions": {
+                    "addStock": "Aggiungi titolo",
+                    "getLastPrice": "Ottieni l'ultimo prezzo"
+                },
+                "table": {
+                    "ticker": "Ticker",
+                    "name": "Nome",
+                    "currency": "Valuta",
+                    "currentPrice": "Prezzo attuale",
+                    "change": "Variazione",
+                    "changePct": "Variazione %",
+                    "high": "Massimo",
+                    "low": "Minimo",
+                    "open": "Prezzo di apertura",
+                    "prevClose": "Chiusura precedente"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Aggiungi titolo" }
                 }
             },
             "pension": {
@@ -2264,6 +2242,28 @@ const I18n = (function() {
                     },
                     "totalValue": "Valoare totală",
                     "saveAddAnother": "Salvați și adăugați altul"
+                }
+            },
+            "watchlist": {
+                "title": "Listă de urmărire",
+                "actions": {
+                    "addStock": "Adaugă acțiune",
+                    "getLastPrice": "Obține ultimul preț"
+                },
+                "table": {
+                    "ticker": "Simbol",
+                    "name": "Nume",
+                    "currency": "Monedă",
+                    "currentPrice": "Preț curent",
+                    "change": "Schimbare",
+                    "changePct": "Schimbare %",
+                    "high": "Maxim",
+                    "low": "Minim",
+                    "open": "Preț de deschidere",
+                    "prevClose": "Închidere anterioară"
+                },
+                "dialogs": {
+                    "addStock": { "title": "Adaugă acțiune" }
                 }
             },
             "pension": {

--- a/app/js/priceUpdater.js
+++ b/app/js/priceUpdater.js
@@ -4,6 +4,7 @@ const PriceUpdater = (function() {
     function checkAndUpdate() {
         if (MarketStatus.isMarketOpen && MarketStatus.isMarketOpen()) {
             PortfolioManager.fetchLastPrices();
+            WatchlistManager.fetchLastPrices();
             StockTracker.fetchLatestPrices();
         }
     }

--- a/app/js/watchlistManager.js
+++ b/app/js/watchlistManager.js
@@ -1,0 +1,125 @@
+const WatchlistManager = (function() {
+    const STORAGE_KEY = 'watchlistData';
+    let watchlist = [];
+
+    const addBtn = document.getElementById('add-watchstock-btn');
+    const getPriceBtn = document.getElementById('watchlist-get-price-btn');
+    const modal = document.getElementById('watchlist-modal');
+    const form = document.getElementById('watchlist-form');
+    const tickerInput = document.getElementById('watchlist-ticker');
+    const nameInput = document.getElementById('watchlist-name');
+    const currencySelect = document.getElementById('watchlist-currency');
+    const closeBtn = document.getElementById('watchlist-close');
+    const cancelBtn = document.getElementById('watchlist-cancel-btn');
+    const tbody = document.getElementById('watchlist-body');
+
+    function save() {
+        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(watchlist)); } catch (e) {}
+    }
+
+    function load() {
+        try {
+            const data = localStorage.getItem(STORAGE_KEY);
+            if (data) watchlist = JSON.parse(data) || [];
+        } catch (e) {
+            watchlist = [];
+        }
+    }
+
+    function formatNumber(val) {
+        return typeof val === 'number' ? val.toFixed(2) : '--';
+    }
+
+    function formatPercent(val) {
+        return typeof val === 'number' ? val.toFixed(2) + '%' : '--';
+    }
+
+    function render() {
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        watchlist.forEach(item => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${item.ticker}</td>
+                <td>${item.name || ''}</td>
+                <td>${item.currency || ''}</td>
+                <td class="number-cell">${formatNumber(item.price)}</td>
+                <td class="number-cell">${formatNumber(item.change)}</td>
+                <td class="number-cell">${formatPercent(item.changePct)}</td>
+                <td class="number-cell">${formatNumber(item.high)}</td>
+                <td class="number-cell">${formatNumber(item.low)}</td>
+                <td class="number-cell">${formatNumber(item.open)}</td>
+                <td class="number-cell">${formatNumber(item.prevClose)}</td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    function openModal() {
+        if (modal) {
+            modal.style.display = 'block';
+            tickerInput.value = '';
+            nameInput.value = '';
+            if (currencySelect) currencySelect.value = 'USD';
+        }
+    }
+
+    function closeModal() {
+        if (modal) modal.style.display = 'none';
+    }
+
+    function addStock(e) {
+        e.preventDefault();
+        const ticker = (tickerInput.value || '').trim().toUpperCase();
+        if (!ticker) return;
+        if (watchlist.some(w => w.ticker === ticker)) {
+            closeModal();
+            form.reset();
+            return;
+        }
+        const item = {
+            ticker,
+            name: (nameInput.value || '').trim(),
+            currency: currencySelect.value || 'USD'
+        };
+        watchlist.push(item);
+        save();
+        render();
+        closeModal();
+        form.reset();
+    }
+
+    async function fetchLastPrices() {
+        if (watchlist.length === 0) return;
+        const updates = watchlist.map(async item => {
+            try {
+                const { raw } = await QuotesService.fetchQuote(item.ticker);
+                if (raw) {
+                    item.price = typeof raw.c === 'number' ? raw.c : null;
+                    item.change = typeof raw.d === 'number' ? raw.d : null;
+                    item.changePct = typeof raw.dp === 'number' ? raw.dp : null;
+                    item.high = typeof raw.h === 'number' ? raw.h : null;
+                    item.low = typeof raw.l === 'number' ? raw.l : null;
+                    item.open = typeof raw.o === 'number' ? raw.o : null;
+                    item.prevClose = typeof raw.pc === 'number' ? raw.pc : null;
+                }
+            } catch (e) {}
+        });
+        await Promise.all(updates);
+        save();
+        render();
+    }
+
+    function init() {
+        load();
+        render();
+        if (addBtn) addBtn.addEventListener('click', openModal);
+        if (closeBtn) closeBtn.addEventListener('click', closeModal);
+        if (cancelBtn) cancelBtn.addEventListener('click', closeModal);
+        if (form) form.addEventListener('submit', addStock);
+        if (getPriceBtn) getPriceBtn.addEventListener('click', fetchLastPrices);
+        window.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+    }
+
+    return { init, fetchLastPrices };
+})();

--- a/app/js/watchlistManager.js
+++ b/app/js/watchlistManager.js
@@ -12,6 +12,8 @@ const WatchlistManager = (function() {
     const closeBtn = document.getElementById('watchlist-close');
     const cancelBtn = document.getElementById('watchlist-cancel-btn');
     const tbody = document.getElementById('watchlist-body');
+    let tickerValid = false;
+    let dragStartIndex = null;
 
     function save() {
         try { localStorage.setItem(STORAGE_KEY, JSON.stringify(watchlist)); } catch (e) {}
@@ -37,30 +39,81 @@ const WatchlistManager = (function() {
     function render() {
         if (!tbody) return;
         tbody.innerHTML = '';
-        watchlist.forEach(item => {
+        watchlist.forEach((item, index) => {
             const tr = document.createElement('tr');
+            tr.dataset.index = index;
+            tr.draggable = true;
+            const changeClass = typeof item.change === 'number' ? (item.change < 0 ? 'growth-negative' : item.change > 0 ? 'growth-positive' : '') : '';
+            const changePctClass = typeof item.changePct === 'number' ? (item.changePct < 0 ? 'growth-negative' : item.changePct > 0 ? 'growth-positive' : '') : '';
             tr.innerHTML = `
                 <td>${item.ticker}</td>
                 <td>${item.name || ''}</td>
                 <td>${item.currency || ''}</td>
                 <td class="number-cell">${formatNumber(item.price)}</td>
-                <td class="number-cell">${formatNumber(item.change)}</td>
-                <td class="number-cell">${formatPercent(item.changePct)}</td>
+                <td class="number-cell ${changeClass}">${formatNumber(item.change)}</td>
+                <td class="number-cell ${changePctClass}">${formatPercent(item.changePct)}</td>
                 <td class="number-cell">${formatNumber(item.high)}</td>
                 <td class="number-cell">${formatNumber(item.low)}</td>
                 <td class="number-cell">${formatNumber(item.open)}</td>
                 <td class="number-cell">${formatNumber(item.prevClose)}</td>
+                <td class="actions-cell">
+                    <button class="icon-btn delete-btn" data-index="${index}" title="${I18n.t('watchlist.actions.delete')}">
+                        <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
+                    </button>
+                </td>
             `;
+            const delBtn = tr.querySelector('.delete-btn');
+            delBtn.addEventListener('click', () => deleteStock(index));
+            addDragHandlers(tr);
             tbody.appendChild(tr);
         });
     }
 
+    function deleteStock(index) {
+        watchlist.splice(index, 1);
+        save();
+        render();
+    }
+
+    function handleDragStart() {
+        dragStartIndex = parseInt(this.dataset.index, 10);
+        this.classList.add('dragging');
+    }
+
+    function handleDragOver(e) {
+        e.preventDefault();
+    }
+
+    function handleDrop() {
+        const dropIndex = parseInt(this.dataset.index, 10);
+        if (dragStartIndex === null || dragStartIndex === dropIndex) return;
+        const item = watchlist.splice(dragStartIndex, 1)[0];
+        const targetIndex = dragStartIndex < dropIndex ? dropIndex - 1 : dropIndex;
+        watchlist.splice(targetIndex, 0, item);
+        dragStartIndex = null;
+        save();
+        render();
+    }
+
+    function handleDragEnd() {
+        this.classList.remove('dragging');
+    }
+
+    function addDragHandlers(row) {
+        row.addEventListener('dragstart', handleDragStart);
+        row.addEventListener('dragover', handleDragOver);
+        row.addEventListener('drop', handleDrop);
+        row.addEventListener('dragend', handleDragEnd);
+    }
+
     function openModal() {
         if (modal) {
-            modal.style.display = 'block';
+            modal.style.display = 'flex';
             tickerInput.value = '';
             nameInput.value = '';
+            tickerValid = false;
             if (currencySelect) currencySelect.value = 'USD';
+            tickerInput.focus();
         }
     }
 
@@ -71,22 +124,51 @@ const WatchlistManager = (function() {
     function addStock(e) {
         e.preventDefault();
         const ticker = (tickerInput.value || '').trim().toUpperCase();
-        if (!ticker) return;
+        const name = (nameInput.value || '').trim();
+        const currency = currencySelect.value || 'USD';
+        if (!tickerValid) {
+            DialogManager.alert(I18n.t('dialog.enterValidTicker'));
+            return;
+        }
         if (watchlist.some(w => w.ticker === ticker)) {
             closeModal();
             form.reset();
             return;
         }
-        const item = {
-            ticker,
-            name: (nameInput.value || '').trim(),
-            currency: currencySelect.value || 'USD'
-        };
-        watchlist.push(item);
+        watchlist.push({ ticker, name, currency });
         save();
         render();
         closeModal();
         form.reset();
+    }
+
+    async function handleTickerLookup() {
+        const ticker = (tickerInput.value || '').trim().toUpperCase();
+        if (!ticker) {
+            tickerValid = false;
+            return;
+        }
+        const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000));
+        try {
+            const [{ price, currency }, description] = await Promise.race([
+                Promise.all([
+                    QuotesService.fetchQuote(ticker),
+                    QuotesService.searchSymbol(ticker)
+                ]),
+                timeout
+            ]);
+            if (currency) currencySelect.value = currency;
+            if (description) {
+                nameInput.value = description;
+                tickerValid = true;
+            } else {
+                tickerValid = false;
+                nameInput.value = '';
+                DialogManager.alert(I18n.t('dialog.tickerNotExist'));
+            }
+        } catch (e) {
+            tickerValid = true;
+        }
     }
 
     async function fetchLastPrices() {
@@ -118,6 +200,10 @@ const WatchlistManager = (function() {
         if (cancelBtn) cancelBtn.addEventListener('click', closeModal);
         if (form) form.addEventListener('submit', addStock);
         if (getPriceBtn) getPriceBtn.addEventListener('click', fetchLastPrices);
+        if (tickerInput) {
+            tickerInput.addEventListener('change', handleTickerLookup);
+            tickerInput.addEventListener('blur', handleTickerLookup);
+        }
         window.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
     }
 


### PR DESCRIPTION
## Summary
- add Watchlist tab with table and modal for tracking stock quotes
- support translations for watchlist labels across languages
- update price updater and tests to include watchlist

## Testing
- `npm test --prefix app/js`

------
https://chatgpt.com/codex/tasks/task_e_689a53e886c8832fb27310cfaa644071