### PR TITLE
Allow price updates during extended market sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ personal-finance-dashboard/
 │       ├── stockTracker.js       # Stock performance tracker
 │       ├── stockFinance.js       # Financial statements
 │       ├── pensionManager.js     # Pension tracking
-│       ├── priceUpdater.js       # Portfolio-wide price refresh
+│       ├── priceUpdater.js       # Portfolio-wide price refresh during pre-, regular, and after-market sessions
 │       ├── forexData.js          # Foreign exchange data
 │       ├── dateUtils.js          # Date helper functions
 │       ├── settings.js           # Application settings

--- a/TECHNICAL_DOCUMENTATION.md
+++ b/TECHNICAL_DOCUMENTATION.md
@@ -398,7 +398,7 @@ No build process required - the application runs directly in the browser.
 - `financialDashboard.js` → orchestrates modules:
   - UI infrastructure: `tabManager.js`, `dialogManager.js`
   - Feature modules: `portfolioManager.js`, `pensionManager.js`, `calculator.js`, `stockTracker.js`, `stockFinance.js`, `settings.js`
-  - Utilities: `i18n.js`, `dateUtils.js`, `forexData.js`, `marketStatus.js`, `priceUpdater.js`, `appVersion.js`
+  - Utilities: `i18n.js`, `dateUtils.js`, `forexData.js`, `marketStatus.js`, `priceUpdater.js` (pre-, regular, and after-market refresh), `appVersion.js`
 - Visualization: `chart.umd.js` (Chart.js)
 
 Textual flow:

--- a/__tests__/marketStatus.test.js
+++ b/__tests__/marketStatus.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const vm = require('vm');
+
+function loadMarketStatus(response) {
+  const html = '<!DOCTYPE html><html><body>' +
+    '<div id="market-led"></div>' +
+    '<span id="market-session"></span>' +
+    '<div id="early-led"></div>' +
+    '<span id="early-session"></span>' +
+    '<div id="after-led"></div>' +
+    '<span id="after-session"></span>' +
+    '</body></html>';
+  const dom = new JSDOM(html, { url: 'http://localhost' });
+  const context = vm.createContext(dom.window);
+  dom.window.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(response) });
+  dom.window.setInterval = () => {};
+  const code = fs.readFileSync(path.resolve(__dirname, '../app/js/marketStatus.js'), 'utf8');
+  vm.runInContext(code, context);
+  return context;
+}
+
+test('isMarketOpen true during pre-market', async () => {
+  const context = loadMarketStatus({ market: 'closed', earlyHours: true, afterHours: false });
+  vm.runInContext('MarketStatus.init();', context);
+  await new Promise(r => setTimeout(r, 0));
+  const result = vm.runInContext('MarketStatus.isMarketOpen()', context);
+  expect(result).toBe(true);
+});
+
+test('isMarketOpen true during after-hours', async () => {
+  const context = loadMarketStatus({ market: 'closed', earlyHours: false, afterHours: true });
+  vm.runInContext('MarketStatus.init();', context);
+  await new Promise(r => setTimeout(r, 0));
+  const result = vm.runInContext('MarketStatus.isMarketOpen()', context);
+  expect(result).toBe(true);
+});
+
+test('isMarketOpen false when all sessions closed', async () => {
+  const context = loadMarketStatus({ market: 'closed', earlyHours: false, afterHours: false });
+  vm.runInContext('MarketStatus.init();', context);
+  await new Promise(r => setTimeout(r, 0));
+  const result = vm.runInContext('MarketStatus.isMarketOpen()', context);
+  expect(result).toBe(false);
+});

--- a/app/js/marketStatus.js
+++ b/app/js/marketStatus.js
@@ -1,6 +1,6 @@
 // Market Status Indicator
 const MarketStatus = (function() {
-    // Uses Polygon.io to check current US market status
+    // Uses Polygon.io to check current US market status including pre-market and after-hours sessions
     const API_KEY = 'hQmiS4FP5wJQrg8rX3gTMane2digQcLF';
     const ledEl = document.getElementById('market-led');
     const sessionEl = document.getElementById('market-session');
@@ -20,7 +20,7 @@ const MarketStatus = (function() {
             const isOpen = data && data.market === 'open';
             const earlyOpen = data && data.earlyHours === true;
             const afterOpen = data && data.afterHours === true;
-            marketOpen = !!isOpen;
+            marketOpen = !!(isOpen || earlyOpen || afterOpen);
             ledEl.classList.toggle('led-green', isOpen);
             ledEl.classList.toggle('led-red', !isOpen);
             if (earlyLedEl) {


### PR DESCRIPTION
## Summary
- Treat Polygon pre- and after-hours flags as open market sessions
- Document price updater extended-hours capability
- Cover extended-hours logic with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bbbbfc47c832fb2d4472ae07f5080