### PR TITLE
Add watchlist data management options and spacing fix

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -295,6 +295,10 @@
             align-self: flex-start;
         }
 
+        #settings-finnhub-api-key + label {
+            margin-top: 0.5rem;
+        }
+
         .form-group input:focus, .form-group select:focus {
             outline: none;
             border-color: var(--primary-blue);

--- a/app/index.html
+++ b/app/index.html
@@ -914,6 +914,15 @@
                     </div>
                 </div>
 
+                <h3 class="section-subtitle" data-i18n="settings.sectionTitles.watchlist">Watchlist</h3>
+                <div class="form-group">
+                    <div class="button-row">
+                        <button type="button" class="btn btn-secondary" id="export-watchlist-btn" data-i18n="settings.exportWatchlist">Export Watchlist</button>
+                        <button type="button" class="btn btn-secondary" id="import-watchlist-btn" data-i18n="settings.importWatchlist">Import Watchlist</button>
+                        <button type="button" class="btn btn-danger" id="delete-watchlist-btn" data-i18n="settings.deleteWatchlist">Delete Watchlist</button>
+                    </div>
+                </div>
+
                 <h3 class="section-subtitle" data-i18n="settings.sectionTitles.stockTracker">Stock Performance Tracker</h3>
                 <div class="form-group">
                     <div class="button-row">
@@ -1010,6 +1019,48 @@
                 </div>
                 <div class="modal-actions">
                     <button type="button" class="btn btn-secondary" id="cancel-import-portfolio" data-i18n="common.cancel">Cancel</button>
+                    <button type="submit" class="btn btn-primary" data-i18n="common.import">Import</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Export Watchlist Modal -->
+    <div id="export-watchlist-modal" class="modal">
+        <div class="modal-content">
+            <h3 data-i18n="settings.exportWatchlist">Export Watchlist</h3>
+            <div class="form-group">
+                <label for="export-watchlist-format" data-i18n="common.format">Format</label>
+                <select id="export-watchlist-format">
+                    <option value="json">JSON</option>
+                    <option value="csv">CSV</option>
+                </select>
+            </div>
+            <div class="modal-actions">
+                <button type="button" class="btn btn-secondary" id="cancel-export-watchlist" data-i18n="common.cancel">Cancel</button>
+                <button type="button" class="btn btn-primary" id="download-export-watchlist" data-i18n="common.export">Export</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Import Watchlist Modal -->
+    <div id="import-watchlist-modal" class="modal">
+        <div class="modal-content">
+            <h3 data-i18n="settings.importWatchlist">Import Watchlist</h3>
+            <form id="import-watchlist-form">
+                <div class="form-group">
+                    <label for="import-watchlist-format" data-i18n="common.format">Format</label>
+                    <select id="import-watchlist-format">
+                        <option value="json">JSON</option>
+                        <option value="csv">CSV</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="import-watchlist-file" data-i18n="common.file">File</label>
+                    <input type="file" id="import-watchlist-file" accept=".json,.csv" required>
+                </div>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn-secondary" id="cancel-import-watchlist" data-i18n="common.cancel">Cancel</button>
                     <button type="submit" class="btn btn-primary" data-i18n="common.import">Import</button>
                 </div>
             </form>

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -318,6 +318,7 @@ const I18n = (function() {
                 "language": "Language",
                 "pension": "Pension",
                 "portfolio": "Portfolio",
+                "watchlist": "Watchlist",
                 "stockTracker": "Stock Performance Tracker",
                 "about": "About"
                 },
@@ -332,6 +333,9 @@ const I18n = (function() {
                 "exportPortfolio": "Export Portfolio",
                   "importPortfolio": "Import Portfolio",
                   "deletePortfolio": "Delete Portfolio",
+                "exportWatchlist": "Export Watchlist",
+                "importWatchlist": "Import Watchlist",
+                "deleteWatchlist": "Delete Watchlist",
                 "exportStock": "Export Stock Data",
                 "importStock": "Import Stock Data",
                 "deleteStock": "Delete Data",
@@ -357,6 +361,7 @@ const I18n = (function() {
                 "deleteEntry": "Delete this entry?",
                 "deleteAllPension": "Delete all pension data?",
                 "deleteAllPortfolio": "Delete all portfolio data?",
+                "deleteAllWatchlist": "Delete all watchlist data?",
                 "deleteAllStock": "Delete all stock tracker data?"
             },
             "common": {
@@ -684,6 +689,7 @@ const I18n = (function() {
                 "language": "Gjuha",
                 "pension": "Pensioni",
                 "portfolio": "Portofoli",
+                "watchlist": "Lista e Vëzhgimit",
                 "stockTracker": "Ndjekësi i Performancës së Aksioneve",
                 "about": "Rreth"
                 },
@@ -698,6 +704,9 @@ const I18n = (function() {
                 "exportPortfolio": "Eksporto Portofolin",
                   "importPortfolio": "Importo Portofolin",
                   "deletePortfolio": "Fshi Portofolin",
+                "exportWatchlist": "Eksporto Listën e Vëzhgimit",
+                "importWatchlist": "Importo Listën e Vëzhgimit",
+                "deleteWatchlist": "Fshi Listën e Vëzhgimit",
                 "exportStock": "Eksporto të Dhënat e Aksioneve",
                 "importStock": "Importo të Dhënat e Aksioneve",
                 "deleteStock": "Fshi të Dhënat",
@@ -723,6 +732,7 @@ const I18n = (function() {
                 "deleteEntry": "Ta fshij këtë shënim?",
                 "deleteAllPension": "Të fshij të gjithë të dhënat e pensionit?",
                 "deleteAllPortfolio": "Të fshij të gjitha të dhënat e portofolit?",
+                "deleteAllWatchlist": "Të fshij të gjitha të dhënat e listës së vëzhgimit?",
                 "deleteAllStock": "Të fshij të gjitha të dhënat e gjurmuesit të aksioneve?"
             },
             "common": {
@@ -1050,6 +1060,7 @@ const I18n = (function() {
                 "language": "Langue",
                 "pension": "Pension",
                 "portfolio": "Portefeuille",
+                "watchlist": "Liste de surveillance",
                 "stockTracker": "Suivi de Performance des Actions",
                 "about": "À propos"
                 },
@@ -1064,6 +1075,9 @@ const I18n = (function() {
                   "exportPortfolio": "Exporter le Portefeuille",
                   "importPortfolio": "Importer le Portefeuille",
                   "deletePortfolio": "Supprimer le Portefeuille",
+                "exportWatchlist": "Exporter la liste de surveillance",
+                "importWatchlist": "Importer la liste de surveillance",
+                "deleteWatchlist": "Supprimer la liste de surveillance",
                 "exportStock": "Exporter les Données d'Actions",
                 "importStock": "Importer les Données d'Actions",
                 "deleteStock": "Supprimer les Données",
@@ -1089,6 +1103,7 @@ const I18n = (function() {
                 "deleteEntry": "Supprimer cette entrée ?",
                 "deleteAllPension": "Supprimer toutes les données de retraite ?",
                 "deleteAllPortfolio": "Supprimer toutes les données de portefeuille ?",
+                "deleteAllWatchlist": "Supprimer toutes les données de la liste de surveillance ?",
                 "deleteAllStock": "Supprimer toutes les données du suivi des actions ?"
             },
             "common": {
@@ -1416,6 +1431,7 @@ const I18n = (function() {
                 "language": "Sprache",
                 "pension": "Rente",
                 "portfolio": "Portfolio",
+                "watchlist": "Beobachtungsliste",
                 "stockTracker": "Aktien-Performance-Tracker",
                 "about": "Über"
                 },
@@ -1430,6 +1446,9 @@ const I18n = (function() {
                   "exportPortfolio": "Portfolio exportieren",
                   "importPortfolio": "Portfolio importieren",
                   "deletePortfolio": "Portfolio löschen",
+                "exportWatchlist": "Beobachtungsliste exportieren",
+                "importWatchlist": "Beobachtungsliste importieren",
+                "deleteWatchlist": "Beobachtungsliste löschen",
                 "exportStock": "Aktien-Daten exportieren",
                 "importStock": "Aktien-Daten importieren",
                 "deleteStock": "Daten löschen",
@@ -1455,6 +1474,7 @@ const I18n = (function() {
                 "deleteEntry": "Diesen Eintrag löschen?",
                 "deleteAllPension": "Alle Rentendaten löschen?",
                 "deleteAllPortfolio": "Alle Portfoliodaten löschen?",
+                "deleteAllWatchlist": "Alle Beobachtungsliste-Daten löschen?",
                 "deleteAllStock": "Alle Daten des Aktien-Trackers löschen?"
             },
             "common": {
@@ -1782,6 +1802,7 @@ const I18n = (function() {
                 "language": "Idioma",
                 "pension": "Pensión",
                 "portfolio": "Cartera",
+                "watchlist": "Lista de seguimiento",
                 "stockTracker": "Rastreador de Rendimiento de Acciones",
                 "about": "Acerca de"
                 },
@@ -1796,6 +1817,9 @@ const I18n = (function() {
                   "exportPortfolio": "Exportar Cartera",
                   "importPortfolio": "Importar Cartera",
                   "deletePortfolio": "Eliminar Cartera",
+                "exportWatchlist": "Exportar lista de seguimiento",
+                "importWatchlist": "Importar lista de seguimiento",
+                "deleteWatchlist": "Eliminar lista de seguimiento",
                 "exportStock": "Exportar Datos de Acciones",
                 "importStock": "Importar Datos de Acciones",
                 "deleteStock": "Eliminar Datos",
@@ -1821,6 +1845,7 @@ const I18n = (function() {
                 "deleteEntry": "¿Eliminar esta entrada?",
                 "deleteAllPension": "¿Eliminar todos los datos de pensión?",
                 "deleteAllPortfolio": "¿Eliminar todos los datos de portafolio?",
+                "deleteAllWatchlist": "¿Eliminar todos los datos de la lista de seguimiento?",
                 "deleteAllStock": "¿Eliminar todos los datos del rastreador de acciones?"
             },
             "common": {
@@ -2148,6 +2173,7 @@ const I18n = (function() {
                 "language": "Lingua",
                 "pension": "Pensione",
                 "portfolio": "Portafoglio",
+                "watchlist": "Lista di controllo",
                 "stockTracker": "Tracker delle Prestazioni Azionarie",
                 "about": "Informazioni"
                 },
@@ -2162,6 +2188,9 @@ const I18n = (function() {
                   "exportPortfolio": "Esporta Portafoglio",
                   "importPortfolio": "Importa Portafoglio",
                   "deletePortfolio": "Elimina Portafoglio",
+                "exportWatchlist": "Esporta lista di controllo",
+                "importWatchlist": "Importa lista di controllo",
+                "deleteWatchlist": "Elimina lista di controllo",
                 "exportStock": "Esporta Dati Azionari",
                 "importStock": "Importa Dati Azionari",
                 "deleteStock": "Elimina Dati",
@@ -2187,6 +2216,7 @@ const I18n = (function() {
                 "deleteEntry": "Eliminare questa voce?",
                 "deleteAllPension": "Eliminare tutti i dati della pensione?",
                 "deleteAllPortfolio": "Eliminare tutti i dati del portafoglio?",
+                "deleteAllWatchlist": "Eliminare tutti i dati della lista di controllo?",
                 "deleteAllStock": "Eliminare tutti i dati del tracker azionario?"
             },
             "common": {
@@ -2518,6 +2548,7 @@ const I18n = (function() {
                     "language": "Limbă",
                     "pension": "Pensiune",
                     "portfolio": "Portofoliu",
+                    "watchlist": "Lista de urmărire",
                     "stockTracker": "Monitorizare performanță acțiuni",
                     "about": "Despre"
                 },
@@ -2532,6 +2563,9 @@ const I18n = (function() {
                 "exportPortfolio": "Portofoliu de export",
                 "importPortfolio": "Portofoliu de import",
                 "deletePortfolio": "Ștergeți portofoliul",
+                "exportWatchlist": "Exportă lista de urmărire",
+                "importWatchlist": "Importă lista de urmărire",
+                "deleteWatchlist": "Șterge lista de urmărire",
                 "exportStock": "Date de stoc de export",
                 "importStock": "Importați datele stocului",
                 "deleteStock": "Ștergeți datele",
@@ -2557,6 +2591,7 @@ const I18n = (function() {
                 "deleteEntry": "Ștergeți această intrare?",
                 "deleteAllPension": "Ștergeți toate datele de pensii?",
                 "deleteAllPortfolio": "Ștergeți toate datele din portofoliu?",
+                "deleteAllWatchlist": "Ștergeți toate datele listei de urmărire?",
                 "deleteAllStock": "Ștergeți toate datele de urmărire a stocurilor?"
             },
             "common": {

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -180,6 +180,18 @@ const Settings = (function() {
         const impPortfolioFile = document.getElementById('import-portfolio-file');
         const impPortfolioCancel = document.getElementById('cancel-import-portfolio');
         const delPortfolioBtn = document.getElementById('delete-portfolio-btn');
+        const expWatchlistBtn = document.getElementById('export-watchlist-btn');
+        const impWatchlistBtn = document.getElementById('import-watchlist-btn');
+        const delWatchlistBtn = document.getElementById('delete-watchlist-btn');
+        const expWatchlistModal = document.getElementById('export-watchlist-modal');
+        const expWatchlistFormat = document.getElementById('export-watchlist-format');
+        const expWatchlistCancel = document.getElementById('cancel-export-watchlist');
+        const expWatchlistDownload = document.getElementById('download-export-watchlist');
+        const impWatchlistModal = document.getElementById('import-watchlist-modal');
+        const impWatchlistForm = document.getElementById('import-watchlist-form');
+        const impWatchlistFormat = document.getElementById('import-watchlist-format');
+        const impWatchlistFile = document.getElementById('import-watchlist-file');
+        const impWatchlistCancel = document.getElementById('cancel-import-watchlist');
         const expStockBtn = document.getElementById('export-stock-btn');
         const impStockBtn = document.getElementById('import-stock-btn');
         const delStockBtn = document.getElementById('delete-stock-btn');
@@ -285,6 +297,52 @@ const Settings = (function() {
             reader.readAsText(file);
         }
 
+        function openWatchlistExport() {
+            expWatchlistFormat.value = 'json';
+            expWatchlistModal.style.display = 'flex';
+        }
+
+        function closeWatchlistExport() {
+            expWatchlistModal.style.display = 'none';
+        }
+
+        function downloadWatchlistExport() {
+            const fmt = expWatchlistFormat.value;
+            const data = WatchlistManager.exportData(fmt);
+            const blob = new Blob([data], { type: fmt === 'json' ? 'application/json' : 'text/csv' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = 'watchlist.' + (fmt === 'json' ? 'json' : 'csv');
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(a.href);
+            closeWatchlistExport();
+        }
+
+        function openWatchlistImport() {
+            impWatchlistFormat.value = 'json';
+            if (impWatchlistFile) impWatchlistFile.value = '';
+            if (impWatchlistFile) impWatchlistFile.focus();
+            impWatchlistModal.style.display = 'flex';
+        }
+
+        function closeWatchlistImport() {
+            impWatchlistModal.style.display = 'none';
+        }
+
+        function handleWatchlistImport(e) {
+            e.preventDefault();
+            const file = impWatchlistFile.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = function() {
+                WatchlistManager.importData(reader.result, impWatchlistFormat.value);
+                closeWatchlistImport();
+            };
+            reader.readAsText(file);
+        }
+
         function openStockExport() {
             expStockFormat.value = 'json';
             expStockModal.style.display = 'flex';
@@ -337,6 +395,11 @@ const Settings = (function() {
         if (expPortfolioDownload) expPortfolioDownload.addEventListener('click', downloadPortfolioExport);
         if (expPortfolioModal) expPortfolioModal.addEventListener('click', e => { if (e.target === expPortfolioModal) closePortfolioExport(); });
 
+        if (expWatchlistBtn) expWatchlistBtn.addEventListener('click', openWatchlistExport);
+        if (expWatchlistCancel) expWatchlistCancel.addEventListener('click', closeWatchlistExport);
+        if (expWatchlistDownload) expWatchlistDownload.addEventListener('click', downloadWatchlistExport);
+        if (expWatchlistModal) expWatchlistModal.addEventListener('click', e => { if (e.target === expWatchlistModal) closeWatchlistExport(); });
+
         if (expStockBtn) expStockBtn.addEventListener('click', openStockExport);
         if (expStockCancel) expStockCancel.addEventListener('click', closeStockExport);
         if (expStockDownload) expStockDownload.addEventListener('click', downloadStockExport);
@@ -346,6 +409,11 @@ const Settings = (function() {
         if (impPortfolioCancel) impPortfolioCancel.addEventListener('click', closePortfolioImport);
         if (impPortfolioForm) impPortfolioForm.addEventListener('submit', handlePortfolioImport);
         if (impPortfolioModal) impPortfolioModal.addEventListener('click', e => { if (e.target === impPortfolioModal) closePortfolioImport(); });
+
+        if (impWatchlistBtn) impWatchlistBtn.addEventListener('click', openWatchlistImport);
+        if (impWatchlistCancel) impWatchlistCancel.addEventListener('click', closeWatchlistImport);
+        if (impWatchlistForm) impWatchlistForm.addEventListener('submit', handleWatchlistImport);
+        if (impWatchlistModal) impWatchlistModal.addEventListener('click', e => { if (e.target === impWatchlistModal) closeWatchlistImport(); });
 
         if (impStockBtn) impStockBtn.addEventListener('click', openStockImport);
         if (impStockCancel) impStockCancel.addEventListener('click', closeStockImport);
@@ -364,6 +432,13 @@ const Settings = (function() {
             delPortfolioBtn.addEventListener('click', async () => {
                 const c = await DialogManager.confirm(I18n.t('dialog.deleteAllPortfolio'), I18n.t('dialog.delete'));
                 if (c) PortfolioManager.deleteAllData();
+            });
+        }
+
+        if (delWatchlistBtn) {
+            delWatchlistBtn.addEventListener('click', async () => {
+                const c = await DialogManager.confirm(I18n.t('dialog.deleteAllWatchlist'), I18n.t('dialog.delete'));
+                if (c) WatchlistManager.deleteAllData();
             });
         }
 


### PR DESCRIPTION
## Summary
- Space out API key input from visibility toggle in Settings
- Add Watchlist export, import, and delete controls with modals
- Enable Watchlist data persistence operations and translate new labels

## Testing
- `cd app/js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bcad0eef0832fb5156b84acf0df2b