### PR TITLE
Add last update timestamp to watchlist

### DIFF
--- a/DOCUMENTATION_SUMMARY.md
+++ b/DOCUMENTATION_SUMMARY.md
@@ -219,6 +219,7 @@ This comprehensive documentation package ensures the Personal Finance Dashboard 
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.
 - Base-currency calculations and sticky table improvements.
 - Automatic input focus in dialog and edit modals.
+- Watchlist now displays last price update timestamps.
 - Documentation updated for modularized codebase.
 - `.gitignore` improvements noted.
 - See [RULES.md](RULES.md) for contribution guidelines.

--- a/__tests__/html.test.js
+++ b/__tests__/html.test.js
@@ -39,7 +39,7 @@ test('watchlist tab and table headers exist', () => {
   const tab = doc.querySelector('button.nav-tab[data-tab="watchlist"]');
   expect(tab).not.toBeNull();
   const headers = Array.from(doc.querySelectorAll('#watchlist-table thead th')).map(th => th.textContent.trim());
-  ['Ticker','Name','Currency','Current Price','Change','Change %','High','Low','Open Price','Previous Close','Actions'].forEach(h => {
+  ['Ticker','Name','Currency','Current Price','Change','Change %','High','Low','Open Price','Previous Close','Last Update','Actions'].forEach(h => {
     expect(headers).toContain(h);
   });
 });

--- a/__tests__/watchlistManager.test.js
+++ b/__tests__/watchlistManager.test.js
@@ -36,4 +36,6 @@ test('stores websocket price updates in localStorage', () => {
   ws.listeners.message({ data: JSON.stringify({ type: 'trade', data: [{ s: 'AAPL', p: 123.45 }] }) });
   const stored = vm.runInContext('PriceStorage.getAll()', context);
   expect(stored.AAPL.price).toBe(123.45);
+  const lastUpdate = vm.runInContext('JSON.parse(localStorage.getItem("watchlistData"))[0].lastUpdate', context);
+  expect(typeof lastUpdate).toBe('number');
 });

--- a/app/index.html
+++ b/app/index.html
@@ -282,6 +282,7 @@
                                 <th data-i18n="watchlist.table.low">Low</th>
                                 <th data-i18n="watchlist.table.open">Open Price</th>
                                 <th data-i18n="watchlist.table.prevClose">Previous Close</th>
+                                <th data-i18n="watchlist.table.lastUpdate">Last Update</th>
                                 <th data-i18n="watchlist.table.actions">Actions</th>
                             </tr>
                         </thead>

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -86,6 +86,7 @@ const I18n = (function() {
                     "low": "Low",
                     "open": "Open Price",
                     "prevClose": "Previous Close",
+                    "lastUpdate": "Last Update",
                     "actions": "Actions"
                 },
                 "dialogs": {
@@ -455,6 +456,7 @@ const I18n = (function() {
                     "low": "Më i Ulëti",
                     "open": "Çmimi i Hapjes",
                     "prevClose": "Mbyllja e Mëparshme",
+                    "lastUpdate": "Përditësimi i Fundit",
                     "actions": "Veprimet"
                 },
                 "dialogs": {
@@ -826,6 +828,7 @@ const I18n = (function() {
                     "low": "Bas",
                     "open": "Prix d'ouverture",
                     "prevClose": "Clôture précédente",
+                    "lastUpdate": "Dernière mise à jour",
                     "actions": "Actions"
                 },
                 "dialogs": {
@@ -1197,6 +1200,7 @@ const I18n = (function() {
                     "low": "Tief",
                     "open": "Eröffnungspreis",
                     "prevClose": "Vorheriger Schluss",
+                    "lastUpdate": "Letzte Aktualisierung",
                     "actions": "Aktionen"
                 },
                 "dialogs": {
@@ -1568,6 +1572,7 @@ const I18n = (function() {
                     "low": "Bajo",
                     "open": "Precio de apertura",
                     "prevClose": "Cierre previo",
+                    "lastUpdate": "Última actualización",
                     "actions": "Acciones"
                 },
                 "dialogs": {
@@ -1939,6 +1944,7 @@ const I18n = (function() {
                     "low": "Minimo",
                     "open": "Prezzo di apertura",
                     "prevClose": "Chiusura precedente",
+                    "lastUpdate": "Ultimo aggiornamento",
                     "actions": "Azioni"
                 },
                 "dialogs": {
@@ -2316,6 +2322,7 @@ const I18n = (function() {
                     "low": "Minim",
                     "open": "Preț de deschidere",
                     "prevClose": "Închidere anterioară",
+                    "lastUpdate": "Ultima actualizare",
                     "actions": "Acțiuni"
                 },
                 "dialogs": {

--- a/app/js/watchlistManager.js
+++ b/app/js/watchlistManager.js
@@ -107,6 +107,7 @@ const WatchlistManager = (function() {
                             if (typeof item.low === 'number') {
                                 if (item.low === null || price < item.low) item.low = price;
                             }
+                            item.lastUpdate = Date.now();
                             updated = true;
                         }
                     }
@@ -125,6 +126,15 @@ const WatchlistManager = (function() {
 
     function formatPercent(val) {
         return typeof val === 'number' ? val.toFixed(2) + '%' : '--';
+    }
+
+    function formatDateTime(ts) {
+        if (!ts) return '--';
+        const d = new Date(ts);
+        const pad = n => String(n).padStart(2, '0');
+        const date = `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`;
+        const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+        return `${date} ${time}`;
     }
 
     function render() {
@@ -147,6 +157,7 @@ const WatchlistManager = (function() {
                 <td class="number-cell">${formatNumber(item.low)}</td>
                 <td class="number-cell">${formatNumber(item.open)}</td>
                 <td class="number-cell">${formatNumber(item.prevClose)}</td>
+                <td>${formatDateTime(item.lastUpdate)}</td>
                 <td class="actions-cell">
                     <button class="icon-btn delete-btn" data-index="${index}" title="${I18n.t('watchlist.actions.delete')}">
                         <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
@@ -291,6 +302,7 @@ const WatchlistManager = (function() {
                     item.low = typeof raw.l === 'number' ? raw.l : null;
                     item.open = typeof raw.o === 'number' ? raw.o : null;
                     item.prevClose = typeof raw.pc === 'number' ? raw.pc : null;
+                    item.lastUpdate = Date.now();
                 }
             } catch (e) {}
         });


### PR DESCRIPTION
## Summary
- show a Last Update column in the watchlist table
- track and format the timestamp of the most recent price update for each watchlist entry
- include translations and tests for the new column

## Testing
- `cd app/js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d0c1c6bd8832fa5a81b08fac8b2c1