### PR TITLE
feat: add storage fallback utility

### DIFF
--- a/__tests__/priceStorage.test.js
+++ b/__tests__/priceStorage.test.js
@@ -6,6 +6,8 @@ const vm = require('vm');
 test('notifies handlers on save', () => {
   const dom = new JSDOM('<!DOCTYPE html><body></body>', { url: 'http://localhost' });
   const context = vm.createContext(dom.window);
+  const util = fs.readFileSync(path.resolve(__dirname, '../app/js/storageUtils.js'), 'utf8');
+  vm.runInContext(util, context);
   const code = fs.readFileSync(path.resolve(__dirname, '../app/js/priceStorage.js'), 'utf8');
   vm.runInContext(code, context);
   const spy = jest.fn();
@@ -15,4 +17,18 @@ test('notifies handlers on save', () => {
   expect(spy).toHaveBeenCalled();
   expect(spy.mock.calls[0][0]).toBe('AAPL');
   expect(spy.mock.calls[0][1].price).toBe(111);
+});
+
+test('falls back to memory storage when localStorage disabled', () => {
+  const dom = new JSDOM('<!DOCTYPE html><body></body>', { url: 'http://localhost' });
+  const context = vm.createContext(dom.window);
+  const util = fs.readFileSync(path.resolve(__dirname, '../app/js/storageUtils.js'), 'utf8');
+  vm.runInContext(util, context);
+  // disable localStorage
+  Object.defineProperty(context, 'localStorage', { value: null, configurable: true });
+  const code = fs.readFileSync(path.resolve(__dirname, '../app/js/priceStorage.js'), 'utf8');
+  vm.runInContext(code, context);
+  vm.runInContext('PriceStorage.save("AAPL", 123);', context);
+  const price = vm.runInContext('PriceStorage.get("AAPL").price;', context);
+  expect(price).toBe(123);
 });

--- a/__tests__/storageManager.test.js
+++ b/__tests__/storageManager.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const vm = require('vm');
+
+test('uses memory storage when localStorage is unavailable', () => {
+  const dom = new JSDOM('<!DOCTYPE html><body></body>', { url: 'http://localhost' });
+  const context = vm.createContext(dom.window);
+  const util = fs.readFileSync(path.resolve(__dirname, '../app/js/storageUtils.js'), 'utf8');
+  vm.runInContext(util, context);
+  Object.defineProperty(context, 'localStorage', { value: null, configurable: true });
+  const code = fs.readFileSync(path.resolve(__dirname, '../app/js/storageManager.js'), 'utf8');
+  vm.runInContext(code, context);
+  const added = vm.runInContext('StorageManager.addPortfolioPosition({symbol:"AAPL", quantity:1, purchase_price_per_share:100});', context);
+  expect(added).toBe(true);
+  const positions = vm.runInContext('StorageManager.getPortfolioPositions();', context);
+  expect(positions.length).toBe(1);
+});

--- a/__tests__/watchlistManager.test.js
+++ b/__tests__/watchlistManager.test.js
@@ -22,8 +22,10 @@ function loadWatchlist() {
   window.WebSocket = FakeWebSocket;
   window.localStorage.setItem('watchlistData', JSON.stringify([{ ticker: 'AAPL' }]));
   const context = vm.createContext(window);
+  const utilCode = fs.readFileSync(path.resolve(__dirname, '../app/js/storageUtils.js'), 'utf8');
   const priceStorageCode = fs.readFileSync(path.resolve(__dirname, '../app/js/priceStorage.js'), 'utf8');
   const watchlistCode = fs.readFileSync(path.resolve(__dirname, '../app/js/watchlistManager.js'), 'utf8');
+  vm.runInContext(utilCode, context);
   vm.runInContext(priceStorageCode, context);
   vm.runInContext(watchlistCode, context);
   return { context, FakeWebSocket };

--- a/app/index.html
+++ b/app/index.html
@@ -1135,6 +1135,7 @@
     <script src="js/colorService.js"></script>
     <script src="js/quotesService.js"></script>
     <script src="js/portfolioManager.js"></script>
+    <script src="js/storageUtils.js"></script>
     <script src="js/priceStorage.js"></script>
     <script src="js/watchlistManager.js"></script>
     <script src="js/pensionManager.js"></script>

--- a/app/js/priceStorage.js
+++ b/app/js/priceStorage.js
@@ -1,17 +1,18 @@
 const PriceStorage = (function() {
     const PRICE_STORAGE_KEY = 'latestPrices';
     const handlers = new Set();
+    const storage = StorageUtils.getStorage();
 
     function save(ticker, price) {
         if (!ticker) return;
         let map = {};
         try {
-            map = JSON.parse(localStorage.getItem(PRICE_STORAGE_KEY)) || {};
+            map = JSON.parse(storage.getItem(PRICE_STORAGE_KEY)) || {};
         } catch (e) {}
         const entry = { price, time: Date.now() };
         map[ticker] = entry;
         try {
-            localStorage.setItem(PRICE_STORAGE_KEY, JSON.stringify(map));
+            storage.setItem(PRICE_STORAGE_KEY, JSON.stringify(map));
         } catch (e) {}
         handlers.forEach(fn => {
             try { fn(ticker, entry); } catch (e) {}
@@ -25,7 +26,7 @@ const PriceStorage = (function() {
 
     function getAll() {
         try {
-            return JSON.parse(localStorage.getItem(PRICE_STORAGE_KEY)) || {};
+            return JSON.parse(storage.getItem(PRICE_STORAGE_KEY)) || {};
         } catch (e) {
             return {};
         }

--- a/app/js/storageManager.js
+++ b/app/js/storageManager.js
@@ -37,17 +37,19 @@
     return JSON.parse(json);
   }
 
+  const storage = StorageUtils.getStorage();
+
   function ensureLoaded(){
     if(positions && snapshots) return;
     positions = [];
     snapshots = [];
     try{
-      const ver = parseInt(localStorage.getItem(STORAGE_VERSION_KEY),10);
+      const ver = parseInt(storage.getItem(STORAGE_VERSION_KEY),10);
       if(ver && ver !== VERSION){
         migrate(ver);
       }
-      const posStr = localStorage.getItem(POSITIONS_KEY);
-      const snapStr = localStorage.getItem(SNAPSHOTS_KEY);
+      const posStr = storage.getItem(POSITIONS_KEY);
+      const snapStr = storage.getItem(SNAPSHOTS_KEY);
       if(posStr){
         try{ positions = decompress(posStr); }
         catch(e){ positions = []; }
@@ -66,9 +68,9 @@
     // simple migration placeholder
     positions = [];
     snapshots = [];
-    localStorage.removeItem(POSITIONS_KEY);
-    localStorage.removeItem(SNAPSHOTS_KEY);
-    localStorage.setItem(STORAGE_VERSION_KEY, VERSION);
+    storage.removeItem(POSITIONS_KEY);
+    storage.removeItem(SNAPSHOTS_KEY);
+    storage.setItem(STORAGE_VERSION_KEY, VERSION);
   }
 
   function queueSave(){
@@ -78,14 +80,14 @@
 
   function save(){
     try{
-      localStorage.setItem(STORAGE_VERSION_KEY, VERSION);
-      localStorage.setItem(POSITIONS_KEY, compress(positions));
-      localStorage.setItem(SNAPSHOTS_KEY, compress(snapshots));
+      storage.setItem(STORAGE_VERSION_KEY, VERSION);
+      storage.setItem(POSITIONS_KEY, compress(positions));
+      storage.setItem(SNAPSHOTS_KEY, compress(snapshots));
     }catch(e){
       if(e && e.name === 'QuotaExceededError'){
         // try removing oldest snapshot
         snapshots.shift();
-        try{ localStorage.setItem(SNAPSHOTS_KEY, compress(snapshots)); }
+        try{ storage.setItem(SNAPSHOTS_KEY, compress(snapshots)); }
         catch(err){}
       }
     }

--- a/app/js/storageUtils.js
+++ b/app/js/storageUtils.js
@@ -1,0 +1,35 @@
+const StorageUtils = (function() {
+    'use strict';
+
+    function isLocalStorageAvailable() {
+        try {
+            const test = '__storage_test__';
+            window.localStorage.setItem(test, test);
+            window.localStorage.removeItem(test);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    const memoryStorage = (function() {
+        const store = {};
+        return {
+            getItem(key) {
+                return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+            },
+            setItem(key, value) {
+                store[key] = String(value);
+            },
+            removeItem(key) {
+                delete store[key];
+            }
+        };
+    })();
+
+    function getStorage() {
+        return isLocalStorageAvailable() ? window.localStorage : memoryStorage;
+    }
+
+    return { isLocalStorageAvailable, getStorage };
+})();


### PR DESCRIPTION
## Summary
- add StorageUtils with `isLocalStorageAvailable` and in-memory fallback
- refactor PriceStorage and StorageManager to use StorageUtils
- test graceful degradation when `localStorage` is disabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d84c77510832fbdfe5dee882eeeb2