### PR TITLE
Add aria-labels to icon-only buttons

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -267,6 +267,10 @@ function calculateCAGR(beginValue, endValue, years) {
 - Validate HTML structure
 - Keep markup clean and organized
 
+#### Accessibility Guidelines
+- Provide `aria-label` attributes for icon-only buttons so screen readers can announce their purpose.
+- Verify new UI components using a screen reader or automated accessibility checker.
+
 ### Error Handling
 
 #### Input Validation

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -562,10 +562,10 @@ const PensionManager = (function() {
                 <td class="number-cell ${totalClass}">${formatCurrency(totalVal, baseCurrency)}</td>
                 <td class="number-cell ${totalPctClass}">${st.totalPLPct.toFixed(2)}%</td>
                 ${summaryMode ? '' : `<td class="actions-cell">
-                    <button class="icon-btn edit-btn" data-index="${st.index}" title="Edit">
+                    <button class="icon-btn edit-btn" data-index="${st.index}" title="Edit" aria-label="Edit">
                         <svg width="16" height="16" viewBox="0 0 512 512"><polygon points="364.13 125.25 87 403 64 448 108.99 425 386.75 147.87 364.13 125.25" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><path d="M420.69,68.69,398.07,91.31l22.62,22.63,22.62-22.63a16,16,0,0,0,0-22.62h0A16,16,0,0,0,420.69,68.69Z" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
-                    <button class="icon-btn delete-btn" data-index="${st.index}" title="Delete">
+                    <button class="icon-btn delete-btn" data-index="${st.index}" title="Delete" aria-label="Delete">
                         <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
                 </td>`}

--- a/app/js/portfolioManager.js
+++ b/app/js/portfolioManager.js
@@ -598,10 +598,10 @@ const PortfolioManager = (function() {
                 <td class="pl-cell"></td>
                 <td class="plpct-cell"></td>
                 <td class="actions-cell">
-                    <button class="icon-btn edit-btn" data-index="${inv.index}" title="${I18n.t('portfolio.actions.edit')}">
+                    <button class="icon-btn edit-btn" data-index="${inv.index}" title="${I18n.t('portfolio.actions.edit')}" aria-label="${I18n.t('portfolio.actions.edit')}">
                         <svg width="16" height="16" viewBox="0 0 512 512"><polygon points="364.13 125.25 87 403 64 448 108.99 425 386.75 147.87 364.13 125.25" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><path d="M420.69,68.69,398.07,91.31l22.62,22.63,22.62-22.63a16,16,0,0,0,0-22.62h0A16,16,0,0,0,420.69,68.69Z" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
-                    <button class="icon-btn delete-btn" data-index="${inv.index}" title="${I18n.t('portfolio.actions.delete')}">
+                    <button class="icon-btn delete-btn" data-index="${inv.index}" title="${I18n.t('portfolio.actions.delete')}" aria-label="${I18n.t('portfolio.actions.delete')}">
                         <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
                 </td>`;

--- a/app/js/watchlistManager.js
+++ b/app/js/watchlistManager.js
@@ -159,7 +159,7 @@ const WatchlistManager = (function() {
                 <td class="number-cell">${formatNumber(item.prevClose)}</td>
                 <td>${formatDateTime(item.lastUpdate)}</td>
                 <td class="actions-cell">
-                    <button class="icon-btn delete-btn" data-index="${index}" title="${I18n.t('watchlist.actions.delete')}">
+                    <button class="icon-btn delete-btn" data-index="${index}" title="${I18n.t('watchlist.actions.delete')}" aria-label="${I18n.t('watchlist.actions.delete')}">
                         <svg width="16" height="16" viewBox="0 0 512 512"><path d="M112,112l20,320c.95,18.49,14.4,32,32,32H348c17.67,0,30.87-13.51,32-32l20-320" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="80" y1="112" x2="432" y2="112" style="stroke:currentColor;stroke-linecap:round;stroke-miterlimit:10;stroke-width:32px"/><path d="M192,112V72h0a23.93,23.93,0,0,1,24-24h80a23.93,23.93,0,0,1,24,24h0v40" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="256" y1="176" x2="256" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="184" y1="176" x2="192" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/><line x1="328" y1="176" x2="320" y2="400" style="fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"/></svg>
                     </button>
                 </td>


### PR DESCRIPTION
## Summary
- Improve accessibility by adding `aria-label` to delete/edit buttons in watchlist, portfolio, and pension modules
- Document accessibility guidelines for icon-only buttons in development guide

## Testing
- `npm test --prefix app/js`
- `pa11y app/index.html`

------
https://chatgpt.com/codex/tasks/task_e_689d84b6c6bc832f8aea0d11dbbe153e