### PR TITLE
feat(pension): add total value summary card

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -531,6 +531,7 @@ Notes:
 Users can customize various aspects of the application through the settings interface or by modifying the configuration object.
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -627,6 +627,7 @@ For offline use:
 This development guide should help you understand the codebase structure, development patterns, and best practices for maintaining and extending the Personal Finance Dashboard application.
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/DOCUMENTATION_SUMMARY.md
+++ b/DOCUMENTATION_SUMMARY.md
@@ -214,6 +214,7 @@ This documentation package provides everything needed to understand, use, mainta
 This comprehensive documentation package ensures the Personal Finance Dashboard codebase is well-documented, maintainable, and accessible to users and developers at all levels.
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ This project is open source and available under the MIT License.
 - **Jest & JSDOM** - For reliable testing infrastructure
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/TECHNICAL_DOCUMENTATION.md
+++ b/TECHNICAL_DOCUMENTATION.md
@@ -370,6 +370,7 @@ No build process required - the application runs directly in the browser.
 5. Implement proper state management
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -329,6 +329,7 @@ A: Each browser stores its own data. Different users would need separate browser
 A: Update investment prices weekly or monthly for accurate tracking. More frequent updates provide better insights.
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/agent.md
+++ b/agent.md
@@ -800,6 +800,7 @@ window.addEventListener('error', (event) => {
 This guide should be used alongside the comprehensive [DEVELOPMENT_GUIDE.md](DEVELOPMENT_GUIDE.md) for complete development information. For technical implementation details, refer to [TECHNICAL_DOCUMENTATION.md](TECHNICAL_DOCUMENTATION.md).
 
 ## Latest Changes
+- Pension summary cards now show current total value.
 - Pension tracking with charts and summary view.
 - Portfolio export/import and deletion options.
 - Portfolio and stock tracker price refresh during pre-, regular, and after-market sessions.

--- a/app/index.html
+++ b/app/index.html
@@ -360,6 +360,10 @@
                 </div>
                 <div class="summary-cards" id="pension-summary-cards" style="display:none;">
                     <div class="summary-card">
+                        <h4 data-i18n="pension.summaryCards.totalValue">Total Value</h4>
+                        <p id="pension-total-value"></p>
+                    </div>
+                    <div class="summary-card">
                         <h4 data-i18n="pension.summaryCards.currentCAGR">Current CAGR</h4>
                         <p id="pension-current-cagr"></p>
                     </div>

--- a/app/js/i18n.js
+++ b/app/js/i18n.js
@@ -118,6 +118,7 @@ const I18n = (function() {
                     "actions": "Actions"
                 },
                 "summaryCards": {
+                    "totalValue": "Total Value",
                     "currentCAGR": "Current CAGR",
                     "bestMonth": "Best Month",
                     "worstMonth": "Worst Month",
@@ -489,6 +490,7 @@ const I18n = (function() {
                     "actions": "Veprimet"
                 },
                 "summaryCards": {
+                    "totalValue": "Vlera Totale",
                     "currentCAGR": "CAGR Aktual",
                     "bestMonth": "Muaji Më i Mirë",
                     "worstMonth": "Muaji Më i Keq",
@@ -862,6 +864,7 @@ const I18n = (function() {
                     "actions": "Actions"
                 },
                 "summaryCards": {
+                    "totalValue": "Valeur Totale",
                     "currentCAGR": "CAGR Actuel",
                     "bestMonth": "Meilleur Mois",
                     "worstMonth": "Pire Mois",
@@ -1235,6 +1238,7 @@ const I18n = (function() {
                     "actions": "Aktionen"
                 },
                 "summaryCards": {
+                    "totalValue": "Gesamtwert",
                     "currentCAGR": "Aktueller CAGR",
                     "bestMonth": "Bester Monat",
                     "worstMonth": "Schlechtester Monat",
@@ -1608,6 +1612,7 @@ const I18n = (function() {
                     "actions": "Acciones"
                 },
                 "summaryCards": {
+                    "totalValue": "Valor Total",
                     "currentCAGR": "CAGR Actual",
                     "bestMonth": "Mejor Mes",
                     "worstMonth": "Peor Mes",
@@ -1981,6 +1986,7 @@ const I18n = (function() {
                     "actions": "Azioni"
                 },
                 "summaryCards": {
+                    "totalValue": "Valore Totale",
                     "currentCAGR": "CAGR Attuale",
                     "bestMonth": "Mese Migliore",
                     "worstMonth": "Mese Peggiore",
@@ -2360,6 +2366,7 @@ const I18n = (function() {
                     "actions": "Acțiuni"
                 },
                 "summaryCards": {
+                    "totalValue": "Valoare totală",
                     "currentCAGR": "CAGR curent",
                     "bestMonth": "Cea mai bună lună",
                     "worstMonth": "Cea mai slabă lună",

--- a/app/js/pensionManager.js
+++ b/app/js/pensionManager.js
@@ -445,20 +445,34 @@ const PensionManager = (function() {
     function updateSummaryCards(stats) {
         const container = document.getElementById('pension-summary-cards');
         if (!container) return;
-        if (!stats || stats.length === 0) {
-            container.style.display = 'none';
-            return;
-        }
-        const analysis = computeAnalysis(stats);
-        if (!analysis) {
-            container.style.display = 'none';
-            return;
-        }
+
         const cagrEl = document.getElementById('pension-current-cagr');
         const bestMonthEl = document.getElementById('pension-best-month');
         const worstMonthEl = document.getElementById('pension-worst-month');
         const bestYearEl = document.getElementById('pension-best-year');
         const worstYearEl = document.getElementById('pension-worst-year');
+        const totalValueEl = document.getElementById('pension-total-value');
+
+        const baseCurrency = Settings.getBaseCurrency ? Settings.getBaseCurrency() : 'USD';
+        const current = summaryMode ? summaryInfo : pensions.find(p => p.id === currentPensionId);
+        const startVal = current ? parseFloat(current.start) || 0 : 0;
+        const latestVal = stats && stats.length ? stats[stats.length - 1].value : startVal;
+        if (totalValueEl) totalValueEl.textContent = formatCurrency(latestVal, baseCurrency);
+
+        if (!stats || stats.length === 0) {
+            cagrEl.textContent = bestMonthEl.textContent = worstMonthEl.textContent =
+                bestYearEl.textContent = worstYearEl.textContent = '---';
+            container.style.display = 'flex';
+            return;
+        }
+
+        const analysis = computeAnalysis(stats);
+        if (!analysis) {
+            cagrEl.textContent = bestMonthEl.textContent = worstMonthEl.textContent =
+                bestYearEl.textContent = worstYearEl.textContent = '---';
+            container.style.display = 'flex';
+            return;
+        }
 
         cagrEl.textContent = analysis.cagr ? analysis.cagr.toFixed(2) + '%' : '---';
         bestMonthEl.textContent = analysis.bestMonth ? `${formatDisplayDate(analysis.bestMonth.date)} (${analysis.bestMonth.pct.toFixed(2)}%)` : '---';


### PR DESCRIPTION
## Summary
- show each pension's total value in a new summary card and summary tab
- calculate and render totals in `PensionManager` with i18n strings
- document the new feature across project docs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx jest` *(fails: Could not find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c1c1e54832f8018db185abebc60