### PR TITLE
Fix header/nav gap at reduced view sizes

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -95,14 +95,17 @@
             line-height: 1.6;
         }
 
+        .sticky-top-bar {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+
         .header {
             background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
             color: white;
             padding: 0.6rem 1rem;
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            position: sticky;
-            top: 0;
-            z-index: 1000;
         }
 
         .header-container {
@@ -191,10 +194,6 @@
             display: flex;
             gap: 0;
             overflow-x: auto;
-            position: sticky;
-            top: 0;
-            z-index: 999;
-            margin-top: -1px;
         }
 
         .nav-tab {

--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,7 @@
     <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
 </head>
 <body>
+    <div class="sticky-top-bar">
     <header class="header">
         <div class="container header-container">
             <img src="gosalci_logo.png" alt="GoSalci Logo" class="header-logo">
@@ -54,6 +55,7 @@
         <button class="nav-tab" data-tab="stock-tracker" data-i18n="nav.stockTracker">Stock Performance Tracker</button>
         <button class="nav-tab" data-tab="settings" data-i18n="nav.settings">Settings</button>
     </nav>
+    </div>
 
     <div class="container">
         <div class="content">

--- a/app/js/core/main.js
+++ b/app/js/core/main.js
@@ -9,15 +9,4 @@ document.addEventListener('DOMContentLoaded', async function() {
     PriceUpdater.init();
     ForexData.init();
 
-    const header = document.querySelector('.header');
-    const nav = document.querySelector('.nav-tabs');
-
-    function updateNavOffset() {
-        if (header && nav) {
-            nav.style.top = header.offsetHeight + 'px';
-        }
-    }
-
-    updateNavOffset();
-    window.addEventListener('resize', updateNavOffset);
 });


### PR DESCRIPTION
## Summary

- Wraps `<header>` and `<nav class="nav-tabs">` in a single `<div class="sticky-top-bar">` so they stick to the top as one unit
- Removes individual `position: sticky` from `.header` and `.nav-tabs`
- Removes the now-redundant JS `updateNavOffset()` from `main.js` that was manually setting `nav.style.top`

## Why

When both elements were independently sticky at `top: 0`, reducing the browser view size caused a visible gap between the header and the tab bar (body background showing through). Wrapping them in a single sticky container eliminates the gap entirely at any zoom or font-scale level.

## Test plan

- [x] Verify no gap between page header and nav tabs at default (100%) view size
- [x] Reduce browser/app zoom to 70% — confirm no gap appears
- [x] Scroll down and back up — header + nav tabs stick together correctly
- [x] All tabs still navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)